### PR TITLE
[Refactor] Order cluster update as reduce → config → add, merge FE/WH…

### DIFF
--- a/celerdata-sdk/service/cluster/api.go
+++ b/celerdata-sdk/service/cluster/api.go
@@ -22,6 +22,8 @@ type IClusterAPI interface {
 	ScaleOut(ctx context.Context, req *ScaleOutReq) (*ScaleOutResp, error)
 	ScaleUp(ctx context.Context, req *ScaleUpReq) (*ScaleUpResp, error)
 	UpgradeAMI(ctx context.Context, req *UpgradeAMIReq) (*UpgradeAMIResp, error)
+	ScaleUpFEAndUpgradeAMI(ctx context.Context, req *ScaleUpFEAndUpgradeAMIReq) (*ScaleUpFEAndUpgradeAMIResp, error)
+	ScaleUpWarehouseAndUpgradeAMI(ctx context.Context, req *ScaleUpWarehouseAndUpgradeAMIReq) (*ScaleUpWarehouseAndUpgradeAMIResp, error)
 	IncrStorageSize(ctx context.Context, req *IncrStorageSizeReq) (*IncrStorageSizeResp, error)
 	UnlockFreeTier(ctx context.Context, clusterID string) error
 	GetClusterEndpoints(ctx context.Context, req *GetClusterEndpointsReq) (*GetClusterEndpointsResp, error)
@@ -374,6 +376,24 @@ func (c *clusterAPI) UpgradeAMI(ctx context.Context, req *UpgradeAMIReq) (*Upgra
 		return nil, err
 	}
 
+	return resp, nil
+}
+
+func (c *clusterAPI) ScaleUpFEAndUpgradeAMI(ctx context.Context, req *ScaleUpFEAndUpgradeAMIReq) (*ScaleUpFEAndUpgradeAMIResp, error) {
+	resp := &ScaleUpFEAndUpgradeAMIResp{}
+	err := c.cli.Patch(ctx, fmt.Sprintf("/api/%s/clusters/%s/scale-up-fe-and-upgrade-ami", c.apiVersion, req.ClusterId), req, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *clusterAPI) ScaleUpWarehouseAndUpgradeAMI(ctx context.Context, req *ScaleUpWarehouseAndUpgradeAMIReq) (*ScaleUpWarehouseAndUpgradeAMIResp, error) {
+	resp := &ScaleUpWarehouseAndUpgradeAMIResp{}
+	err := c.cli.Patch(ctx, fmt.Sprintf("/api/%s/warehouses/%s/scale-up-and-upgrade-ami", c.apiVersion, req.WarehouseId), req, resp)
+	if err != nil {
+		return nil, err
+	}
 	return resp, nil
 }
 

--- a/celerdata-sdk/service/cluster/entity.go
+++ b/celerdata-sdk/service/cluster/entity.go
@@ -832,6 +832,31 @@ type UpgradeAMIResp struct {
 	InfraActionId string `json:"infra_action_id" mapstructure:"infra_action_id"`
 }
 
+type ScaleUpFEAndUpgradeAMIReq struct {
+	RequestId  string `json:"request_id" mapstructure:"request_id"`
+	ClusterId  string `json:"cluster_id" mapstructure:"cluster_id"`
+	VmCategory string `json:"vm_category" mapstructure:"vm_category"`
+	Ami        string `json:"ami" mapstructure:"ami"`
+	Os         string `json:"os" mapstructure:"os"`
+}
+
+type ScaleUpFEAndUpgradeAMIResp struct {
+	ActionId string `json:"action_id" mapstructure:"action_id"`
+}
+
+type ScaleUpWarehouseAndUpgradeAMIReq struct {
+	RequestId   string `json:"request_id" mapstructure:"request_id"`
+	ClusterId   string `json:"cluster_id" mapstructure:"cluster_id"`
+	WarehouseId string `json:"warehouse_id" mapstructure:"warehouse_id"`
+	VmCategory  string `json:"vm_category" mapstructure:"vm_category"`
+	Ami         string `json:"ami" mapstructure:"ami"`
+	Os          string `json:"os" mapstructure:"os"`
+}
+
+type ScaleUpWarehouseAndUpgradeAMIResp struct {
+	ActionId string `json:"action_id" mapstructure:"action_id"`
+}
+
 func ConvertStrToCustomConfigType(val string) CustomConfigType {
 	var customConfigType CustomConfigType
 	switch val {

--- a/celerdatabyoc/resource_classic_cluster.go
+++ b/celerdatabyoc/resource_classic_cluster.go
@@ -1157,6 +1157,24 @@ func needUnlock(d *schema.ResourceData) bool {
 			d.HasChange("be_disk_per_size"))
 }
 
+func needFeScaleIn(d *schema.ResourceData) bool {
+	if !d.HasChange("coordinator_node_count") {
+		return false
+	}
+
+	o, n := d.GetChange("coordinator_node_count")
+	return n.(int) < o.(int)
+}
+
+func needFeScaleOut(d *schema.ResourceData) bool {
+	if !d.HasChange("coordinator_node_count") {
+		return false
+	}
+
+	o, n := d.GetChange("coordinator_node_count")
+	return n.(int) > o.(int)
+}
+
 func needResume(d *schema.ResourceData) bool {
 	if !d.HasChange("expected_cluster_state") {
 		return false

--- a/celerdatabyoc/resource_elastic_cluster_v2.go
+++ b/celerdatabyoc/resource_elastic_cluster_v2.go
@@ -1745,6 +1745,7 @@ func resourceElasticClusterV2Update(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(errors.New(stateResp.AbnormalReason))
 	}
 
+	// Top-level flags (config-ish, must run before REDUCE so reductions see the right state)
 	if d.HasChange("idle_suspend_interval") && !d.IsNewResource() {
 		o, n := d.GetChange("idle_suspend_interval")
 
@@ -1764,85 +1765,6 @@ func resourceElasticClusterV2Update(ctx context.Context, d *schema.ResourceData,
 		diagError := HandleChangedClusterSchedulingPolicy(ctx, clusterAPI, d)
 		if diagError != nil {
 			return diagError
-		}
-	}
-
-	// Warning or errors can be collected in a slice type
-	var diags diag.Diagnostics
-	if needResume(d) {
-		o, n := d.GetChange("expected_cluster_state")
-		errDiag := UpdateClusterState(ctx, clusterAPI, d.Get("id").(string), o.(string), n.(string))
-		if errDiag != nil {
-			return errDiag
-		}
-	}
-
-	if d.HasChange("global_session_variables") && !d.IsNewResource() {
-		errDiag := HandleChangedGlobalSqlSessionVariables(ctx, clusterAPI, d)
-		if errDiag != nil {
-			return errDiag
-		}
-	}
-
-	if d.HasChange("ldap_ssl_certs") && !d.IsNewResource() {
-		sslCerts := make([]string, 0)
-		if v, ok := d.GetOk("ldap_ssl_certs"); ok {
-			arr := v.(*schema.Set).List()
-			for _, v := range arr {
-				value := v.(string)
-				sslCerts = append(sslCerts, value)
-			}
-		}
-		warningDiag := UpsertClusterLdapSslCert(ctx, clusterAPI, d.Id(), sslCerts, true)
-		if warningDiag != nil {
-			return warningDiag
-		}
-	}
-
-	if d.HasChange("resource_tags") && !d.IsNewResource() {
-		_, n := d.GetChange("resource_tags")
-
-		nTags := n.(map[string]interface{})
-		tags := make(map[string]string, len(nTags))
-		for k, v := range nTags {
-			tags[k] = v.(string)
-		}
-		err := clusterAPI.UpdateResourceTags(ctx, &cluster.UpdateResourceTagsReq{
-			ClusterId: clusterId,
-			Tags:      tags,
-		})
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("cluster (%s) failed to update resource tags: %s", d.Id(), err.Error()))
-		}
-	}
-
-	if d.HasChange("init_scripts") && !d.IsNewResource() {
-		_, n := d.GetChange("init_scripts")
-		vL := n.(*schema.Set).List()
-		scripts := make([]*cluster.Script, 0, len(vL))
-		for _, v := range vL {
-			s := v.(map[string]interface{})
-			scripts = append(scripts, &cluster.Script{
-				ScriptPath: s["script_path"].(string),
-				LogsDir:    s["logs_dir"].(string),
-			})
-		}
-		err := clusterAPI.UpdateDeploymentScripts(ctx, &cluster.UpdateDeploymentScriptsReq{
-			ClusterId: clusterId,
-			Scripts:   scripts,
-			Parallel:  d.Get("run_scripts_parallel").(bool),
-			Timeout:   int32(d.Get("run_scripts_timeout").(int)),
-		})
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("failed to update cluster(%s) init-scripts: %s", d.Id(), err.Error()))
-		}
-	}
-
-	if d.HasChange("ranger_certs_dir") && !d.IsNewResource() {
-		rangerCertsDirPath := d.Get("ranger_certs_dir").(string)
-		warningDiag := UpsertClusterRangerCert(ctx, clusterAPI, d.Id(), rangerCertsDirPath, true)
-		if warningDiag != nil {
-			return warningDiag
 		}
 	}
 
@@ -1871,6 +1793,15 @@ func resourceElasticClusterV2Update(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(fmt.Errorf("`table_name_case_insensitive` of cluster (%s) cannot be modifeid after the cluster is created", d.Id()))
 	}
 
+	var diags diag.Diagnostics
+	if needResume(d) {
+		o, n := d.GetChange("expected_cluster_state")
+		errDiag := UpdateClusterState(ctx, clusterAPI, d.Get("id").(string), o.(string), n.(string))
+		if errDiag != nil {
+			return errDiag
+		}
+	}
+
 	if elasticClusterV2NeedUnlock(d) {
 		err := clusterAPI.UnlockFreeTier(ctx, clusterId)
 		if err != nil {
@@ -1878,334 +1809,132 @@ func resourceElasticClusterV2Update(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
-	if d.HasChange("coordinator_node_size") && !d.IsNewResource() {
-		_, n := d.GetChange("coordinator_node_size")
-		resp, err := clusterAPI.ScaleUp(ctx, &cluster.ScaleUpReq{
-			RequestId:  uuid.NewString(),
-			ClusterId:  clusterId,
-			ModuleType: cluster.ClusterModuleTypeFE,
-			VmCategory: n.(string),
-		})
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("cluster (%s) failed to scale up fe nodes: %s", d.Id(), err))
-		}
-
-		stateResp, err := WaitClusterStateChangeComplete(ctx, &waitStateReq{
-			clusterAPI:    clusterAPI,
-			actionID:      resp.ActionId,
-			clusterID:     clusterId,
-			timeout:       common.DeployOrScaleClusterTimeout,
-			pendingStates: []string{string(cluster.ClusterStateScaling)},
-			targetStates:  []string{string(cluster.ClusterStateRunning), string(cluster.ClusterStateAbnormal)},
-		})
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("waiting for cluster (%s) running %s", d.Id(), err))
-		}
-
-		if stateResp.ClusterState == string(cluster.ClusterStateAbnormal) {
-			return diag.FromErr(errors.New(stateResp.AbnormalReason))
+	// ---- REDUCE ----
+	if needFeScaleIn(d) {
+		if diags := handleFEScaleIn(ctx, d, clusterAPI, clusterId); diags != nil {
+			return diags
 		}
 	}
 
-	if d.HasChange("coordinator_node_count") && !d.IsNewResource() {
-		o, n := d.GetChange("coordinator_node_count")
+	if diags := handleDeleteWarehouses(ctx, d, clusterAPI, clusterId); diags != nil {
+		return diags
+	}
 
-		var actionID string
-		if n.(int) > o.(int) {
-			resp, err := clusterAPI.ScaleOut(ctx, &cluster.ScaleOutReq{
-				RequestId:  uuid.NewString(),
-				ClusterId:  clusterId,
-				ModuleType: cluster.ClusterModuleTypeFE,
-				ExpectNum:  int32(n.(int)),
-			})
-			if err != nil {
-				return diag.FromErr(fmt.Errorf("cluster (%s) failed to scale out fe nodes: %s", d.Id(), err))
-			}
+	if diags := handleResumeWarehouses(ctx, d, clusterAPI, clusterId); diags != nil {
+		return diags
+	}
 
-			actionID = resp.ActionId
-		} else if n.(int) < o.(int) {
-			resp, err := clusterAPI.ScaleIn(ctx, &cluster.ScaleInReq{
-				RequestId:  uuid.NewString(),
-				ClusterId:  clusterId,
-				ModuleType: cluster.ClusterModuleTypeFE,
-				ExpectNum:  int32(n.(int)),
-			})
-			if err != nil {
-				return diag.FromErr(fmt.Errorf("cluster (%s) failed to scale in fe nodes: %s", d.Id(), err))
-			}
+	if diags := handleScaleInWarehouses(ctx, d, clusterAPI, clusterId); diags != nil {
+		return diags
+	}
 
-			actionID = resp.ActionId
+	// ---- CONFIG ----
+	if d.HasChange("global_session_variables") && !d.IsNewResource() {
+		errDiag := HandleChangedGlobalSqlSessionVariables(ctx, clusterAPI, d)
+		if errDiag != nil {
+			return errDiag
 		}
+	}
 
-		stateResp, err := WaitClusterStateChangeComplete(ctx, &waitStateReq{
-			clusterAPI:    clusterAPI,
-			actionID:      actionID,
-			clusterID:     clusterId,
-			timeout:       common.DeployOrScaleClusterTimeout,
-			pendingStates: []string{string(cluster.ClusterStateScaling)},
-			targetStates:  []string{string(cluster.ClusterStateRunning), string(cluster.ClusterStateAbnormal)},
-		})
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("waiting for cluster (%s) running: %s", d.Id(), err))
+	if d.HasChange("ldap_ssl_certs") && !d.IsNewResource() {
+		if diags := handleLdapSslCertsChange(ctx, d, clusterAPI); diags != nil {
+			return diags
 		}
+	}
 
-		if stateResp.ClusterState == string(cluster.ClusterStateAbnormal) {
-			return diag.FromErr(errors.New(stateResp.AbnormalReason))
+	if d.HasChange("resource_tags") && !d.IsNewResource() {
+		if diags := handleClusterResourceTagsChange(ctx, d, clusterAPI, clusterId); diags != nil {
+			return diags
+		}
+	}
+
+	if d.HasChange("init_scripts") && !d.IsNewResource() {
+		if diags := handleInitScriptsChange(ctx, d, clusterAPI, clusterId); diags != nil {
+			return diags
+		}
+	}
+
+	if d.HasChange("ranger_certs_dir") && !d.IsNewResource() {
+		rangerCertsDirPath := d.Get("ranger_certs_dir").(string)
+		warningDiag := UpsertClusterRangerCert(ctx, clusterAPI, d.Id(), rangerCertsDirPath, true)
+		if warningDiag != nil {
+			return warningDiag
 		}
 	}
 
 	if d.HasChange("coordinator_node_volume_config") {
-		o, n := d.GetChange("coordinator_node_volume_config")
-
-		oldVolumeConfig, newVolumeConfig := cluster.DefaultFeVolumeMap(), cluster.DefaultFeVolumeMap()
-
-		if len(o.([]interface{})) > 0 {
-			oldVolumeConfig = o.([]interface{})[0].(map[string]interface{})
-		}
-		if len(n.([]interface{})) > 0 {
-			newVolumeConfig = n.([]interface{})[0].(map[string]interface{})
-		}
-
-		nodeType := cluster.ClusterModuleTypeFE
-		req := &cluster.ModifyClusterVolumeReq{
-			ClusterId: clusterId,
-			Type:      nodeType,
-		}
-
-		if v, ok := newVolumeConfig["vol_size"]; ok && v != oldVolumeConfig["vol_size"] {
-			req.VmVolSize = int64(v.(int))
-		}
-		if v, ok := newVolumeConfig["iops"]; ok && v != oldVolumeConfig["iops"] {
-			req.Iops = int64(v.(int))
-		}
-		if v, ok := newVolumeConfig["throughput"]; ok && v != oldVolumeConfig["throughput"] {
-			req.Throughput = int64(v.(int))
-		}
-
-		log.Printf("[DEBUG] modify cluster volume detail, req:%+v", req)
-		resp, err := clusterAPI.ModifyClusterVolume(ctx, req)
-		if err != nil {
-			log.Printf("[ERROR] modify cluster volume detail failed, err:%+v", err)
-			return diag.FromErr(err)
-		}
-
-		infraActionId := resp.ActionID
-		if len(infraActionId) > 0 {
-			infraActionResp, err := WaitClusterInfraActionStateChangeComplete(ctx, &waitStateReq{
-				clusterAPI: clusterAPI,
-				clusterID:  clusterId,
-				actionID:   infraActionId,
-				timeout:    30 * time.Minute,
-				pendingStates: []string{
-					string(cluster.ClusterInfraActionStatePending),
-					string(cluster.ClusterInfraActionStateOngoing),
-				},
-				targetStates: []string{
-					string(cluster.ClusterInfraActionStateSucceeded),
-					string(cluster.ClusterInfraActionStateCompleted),
-					string(cluster.ClusterInfraActionStateFailed),
-				},
-			})
-
-			summary := fmt.Sprintf("Modify %s node volume detail of the cluster[%s] failed", nodeType, clusterId)
-			if err != nil {
-				return diag.Diagnostics{
-					diag.Diagnostic{
-						Severity: diag.Error,
-						Summary:  summary,
-						Detail:   err.Error(),
-					},
-				}
-			}
-
-			if infraActionResp.InfraActionState == string(cluster.ClusterInfraActionStateFailed) {
-				return diag.Diagnostics{
-					diag.Diagnostic{
-						Severity: diag.Error,
-						Summary:  summary,
-						Detail:   infraActionResp.ErrMsg,
-					},
-				}
-			}
+		if diags := handleFEVolumeConfigChange(ctx, d, clusterAPI, clusterId); diags != nil {
+			return diags
 		}
 	}
 
 	if d.HasChange("coordinator_node_configs") {
-		configMap := d.Get("coordinator_node_configs").(map[string]interface{})
-		configs := make(map[string]string, 0)
-		for k, v := range configMap {
-			configs[k] = v.(string)
-		}
-		warnDiag := UpsertClusterConfig(ctx, clusterAPI, &cluster.UpsertClusterConfigReq{
-			ClusterID:  clusterId,
-			ConfigType: cluster.CustomConfigTypeFE,
-			Configs:    configs,
-		})
-		if warnDiag != nil {
-			return warnDiag
+		if diags := handleCoordinatorNodeConfigsChange(ctx, d, clusterAPI, clusterId); diags != nil {
+			return diags
 		}
 	}
+
+	if d.HasChange("ranger_config_id") {
+		if diags := handleRangerConfigIDChange(ctx, d, clusterAPI, clusterId); diags != nil {
+			return diags
+		}
+	}
+
+	// ---- MODIFY (size + AMI, merged when both change) ----
+	feScaleUpChanged := d.HasChange("coordinator_node_size") && !d.IsNewResource()
+	customAmiChanged := d.HasChange("custom_ami.0.ami") && !d.IsNewResource()
 
 	netResp, err := networkAPI.GetNetwork(ctx, d.Get("network_id").(string))
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("get network (%s): %s", d.Get("network_id").(string), err.Error()))
 	}
 
-	if d.HasChange("default_warehouse") {
-		o, n := d.GetChange("default_warehouse")
-		oldWh := o.([]interface{})[0].(map[string]interface{})
-		newWh := n.([]interface{})[0].(map[string]interface{})
-		whExternalInfoMap := d.Get("warehouse_external_info").(map[string]interface{})
+	if diags := handleWarehousesChange(ctx, d, clusterAPI, clusterId, netResp.Network.MultiAz, customAmiChanged); diags != nil {
+		return diags
+	}
 
-		// modified
-		whExternalInfoStr := whExternalInfoMap[DEFAULT_WAREHOUSE_NAME].(string)
-		whExternalInfo := &cluster.WarehouseExternalInfo{}
-		json.Unmarshal([]byte(whExternalInfoStr), whExternalInfo)
-		diags := updateWarehouse(ctx, &UpdateWarehouseReq{
-			d:              d,
-			clusterAPI:     clusterAPI,
-			clusterId:      clusterId,
-			oldParamMap:    oldWh,
-			newParamMap:    newWh,
-			whExternalInfo: whExternalInfo,
-		}, netResp.Network.MultiAz)
-		if diags != nil {
+	if diags := handleDefaultWarehouseChange(ctx, d, clusterAPI, clusterId, netResp.Network.MultiAz, customAmiChanged); diags != nil {
+		return diags
+	}
+
+	switch {
+	case feScaleUpChanged && customAmiChanged:
+		if diags := handleFEScaleUpAndUpgradeAMI(ctx, d, clusterAPI, clusterId); diags != nil {
+			return diags
+		}
+	case feScaleUpChanged:
+		if diags := handleFEScaleUp(ctx, d, clusterAPI, clusterId); diags != nil {
+			return diags
+		}
+	case customAmiChanged:
+		// Warehouses already upgraded inside updateWarehouse; only FE AMI remains.
+		if diags := handleFECustomAmiChange(ctx, d, clusterAPI, clusterId); diags != nil {
 			return diags
 		}
 	}
 
-	if d.HasChange("warehouse") {
-		o, n := d.GetChange("warehouse")
-		old := o.([]interface{})
-		new := n.([]interface{})
-		whExternalInfoMap := d.Get("warehouse_external_info").(map[string]interface{})
-
-		oldWhMap := make(map[string]map[string]interface{})
-		for _, v := range old {
-			whMap := v.(map[string]interface{})
-			oldWhMap[whMap["name"].(string)] = whMap
-		}
-		newWhMap := make(map[string]map[string]interface{})
-		for _, v := range new {
-			whMap := v.(map[string]interface{})
-			newWhMap[whMap["name"].(string)] = whMap
-		}
-
-		for _, v := range new {
-			newWh := v.(map[string]interface{})
-			whName := newWh["name"].(string)
-			if oldWh, ok := oldWhMap[whName]; ok {
-				// modified
-				whExternalInfoStr := whExternalInfoMap[whName].(string)
-				whExternalInfo := &cluster.WarehouseExternalInfo{}
-				json.Unmarshal([]byte(whExternalInfoStr), whExternalInfo)
-				diags := updateWarehouse(ctx, &UpdateWarehouseReq{
-					d:              d,
-					clusterAPI:     clusterAPI,
-					clusterId:      clusterId,
-					oldParamMap:    oldWh,
-					newParamMap:    newWh,
-					whExternalInfo: whExternalInfo,
-				}, netResp.Network.MultiAz)
-				if diags != nil {
-					return diags
-				}
-			} else {
-				// added
-				diags := createWarehouse(ctx, clusterAPI, clusterId, newWh)
-				if diags != nil {
-					return diags
-				}
-			}
-		}
-
-		for _, v := range old {
-			oldWh := v.(map[string]interface{})
-			whName := oldWh["name"].(string)
-			if _, ok := newWhMap[whName]; !ok {
-				// removed
-				whExternalInfoStr := whExternalInfoMap[whName].(string)
-				whExternalInfo := &cluster.WarehouseExternalInfo{}
-				json.Unmarshal([]byte(whExternalInfoStr), whExternalInfo)
-				whId := whExternalInfo.Id
-				diags := DeleteWarehouse(ctx, clusterAPI, clusterId, whId)
-				if diags != nil {
-					return diags
-				}
-			}
+	// ---- ADD ----
+	if needFeScaleOut(d) {
+		if diags := handleFEScaleOut(ctx, d, clusterAPI, clusterId); diags != nil {
+			return diags
 		}
 	}
 
+	if diags := handleCreateWarehouses(ctx, d, clusterAPI, clusterId); diags != nil {
+		return diags
+	}
+
+	if diags := handleScaleOutWarehouses(ctx, d, clusterAPI, clusterId); diags != nil {
+		return diags
+	}
+
+	// ---- post ----
 	RunScripts(ctx, RunScriptsReq{
 		ResourceData:       d,
 		ClusterAPI:         clusterAPI,
 		ClusterID:          clusterId,
 		RunScriptsParallel: d.Get("run_scripts_parallel").(bool),
 	})
-
-	if d.HasChange("ranger_config_id") {
-		rangerConfigID := d.Get("ranger_config_id").(string)
-		var warningDiag diag.Diagnostics
-		if rangerConfigID == "" {
-			warningDiag = ClearRangerV2(ctx, clusterAPI, clusterId)
-		} else {
-			warningDiag = ApplyRangerV2(ctx, clusterAPI, clusterId, rangerConfigID)
-		}
-		if warningDiag != nil {
-			return warningDiag
-		}
-	}
-
-	if d.HasChange("custom_ami") && !d.IsNewResource() {
-		o, _ := d.GetChange("custom_ami")
-		if len(o.([]interface{})) == 0 {
-			return diag.FromErr(errors.New("custom ami can only be specified when creating cluster"))
-		}
-
-		if d.HasChange("custom_ami.0.os") && !d.IsNewResource() {
-			oOs, nOs := d.GetChange("custom_ami.0.os")
-			if len(oOs.(string)) > 0 && oOs.(string) != nOs.(string) {
-				return diag.FromErr(errors.New("custom ami os can not be changed"))
-			}
-		}
-
-		if d.HasChange("custom_ami.0.ami") && !d.IsNewResource() {
-			_, nAmi := d.GetChange("custom_ami.0.ami")
-			_, nOs := d.GetChange("custom_ami.0.os")
-
-			clusterResp, err := clusterAPI.Get(ctx, &cluster.GetReq{ClusterID: clusterId})
-			if err != nil {
-				return diag.FromErr(err)
-			}
-
-			if !IsAllRunning(clusterResp.Cluster) {
-				return diag.FromErr(errors.New("custom ami can only be upgraded when the cluster and all warehouse states are running"))
-			}
-
-			for _, wh := range clusterResp.Cluster.Warehouses {
-				err := upgradeAMI(ctx, clusterAPI, &cluster.UpgradeAMIReq{
-					ClusterId:   clusterId,
-					Os:          nOs.(string),
-					Ami:         nAmi.(string),
-					WarehouseId: wh.Id,
-					ModuleType:  cluster.ClusterModuleTypeWarehouse,
-				})
-				if err != nil {
-					return diag.FromErr(err)
-				}
-			}
-
-			err = upgradeAMI(ctx, clusterAPI, &cluster.UpgradeAMIReq{
-				ClusterId:  clusterId,
-				Os:         nOs.(string),
-				Ami:        nAmi.(string),
-				ModuleType: cluster.ClusterModuleTypeFE,
-			})
-			if err != nil {
-				return diag.FromErr(err)
-			}
-		}
-	}
 
 	if needSuspend(d) {
 		o, n := d.GetChange("expected_cluster_state")
@@ -2481,19 +2210,6 @@ func updateWarehouse(ctx context.Context, req *UpdateWarehouseReq, multiAz bool)
 
 	warehouseName := newParamMap["name"].(string)
 
-	if !isDefaultWarehouse {
-		expectedState := newParamMap["expected_state"].(string)
-		expectedStateChanged := oldParamMap["expected_state"].(string) != newParamMap["expected_state"].(string)
-		if expectedStateChanged {
-			if expectedState == string(cluster.ClusterStateRunning) {
-				resp := ResumeWarehouse(ctx, clusterAPI, clusterId, warehouseId, warehouseName)
-				if resp != nil {
-					return resp
-				}
-			}
-		}
-	}
-
 	computeNodeDistributionChanged := oldParamMap["distribution_policy"].(string) != newParamMap["distribution_policy"].(string) ||
 		(newParamMap["distribution_policy"].(string) == string(cluster.DistributionPolicySpecifyAZ) && oldParamMap["specify_az"].(string) != newParamMap["specify_az"].(string))
 	if computeNodeDistributionChanged && multiAz {
@@ -2533,112 +2249,100 @@ func updateWarehouse(ctx context.Context, req *UpdateWarehouseReq, multiAz bool)
 		}
 	}
 
-	// Modify warehouse node size
+	// Modify warehouse node size (optionally combined with AMI upgrade)
 	computeNodeSizeChanged := oldParamMap["compute_node_size"].(string) != newParamMap["compute_node_size"].(string)
 	if computeNodeSizeChanged {
 		vmCate := newParamMap["compute_node_size"].(string)
-		vmCateInfoResp, err := clusterAPI.GetVmInfo(ctx, &cluster.GetVmInfoReq{
-			Csp:         csp,
-			Region:      region,
-			ProcessType: string(cluster.ClusterModuleTypeBE),
-			VmCate:      vmCate,
-		})
-		if err != nil {
-			log.Printf("[ERROR] query vm info failed, csp:%s region:%s vmCate:%s err:%+v", csp, region, vmCate, err)
-			return diag.FromErr(fmt.Errorf("query vm info failed, csp:%s region:%s vmCate:%s errMsg:%s", csp, region, vmCate, err.Error()))
-		}
 
-		if vmCateInfoResp.VmInfo == nil {
-			return diag.FromErr(fmt.Errorf("vm info not exists, csp:%s region:%s vmCate:%s", csp, region, vmCate))
-		}
+		if req.customAmiChanged {
+			if err := handleWarehouseScaleUpAndUpgradeAMI(ctx, req.d, clusterAPI, clusterId, warehouseId, vmCate); err != nil {
+				return diag.FromErr(err)
+			}
+		} else {
+			vmCateInfoResp, err := clusterAPI.GetVmInfo(ctx, &cluster.GetVmInfoReq{
+				Csp:         csp,
+				Region:      region,
+				ProcessType: string(cluster.ClusterModuleTypeBE),
+				VmCate:      vmCate,
+			})
+			if err != nil {
+				log.Printf("[ERROR] query vm info failed, csp:%s region:%s vmCate:%s err:%+v", csp, region, vmCate, err)
+				return diag.FromErr(fmt.Errorf("query vm info failed, csp:%s region:%s vmCate:%s errMsg:%s", csp, region, vmCate, err.Error()))
+			}
 
-		scaleReq := &cluster.ScaleWarehouseSizeReq{
+			if vmCateInfoResp.VmInfo == nil {
+				return diag.FromErr(fmt.Errorf("vm info not exists, csp:%s region:%s vmCate:%s", csp, region, vmCate))
+			}
+
+			scaleReq := &cluster.ScaleWarehouseSizeReq{
+				WarehouseId: warehouseId,
+				VmCate:      vmCate,
+			}
+
+			if computeNodeIsInstanceStore && !vmCateInfoResp.VmInfo.IsInstanceStore {
+				newVolumeConfig := cluster.DefaultBeVolumeMap()
+				if len(newParamMap["compute_node_volume_config"].([]interface{})) > 0 {
+					newVolumeConfig = newParamMap["compute_node_volume_config"].([]interface{})[0].(map[string]interface{})
+				}
+
+				if newVolumeConfig["vol_number"].(int) > int(vmCateInfoResp.VmInfo.MaxDataDiskCount) {
+					return diag.FromErr(fmt.Errorf("the maximum allowed `vol_number` for this VM type is: %d", vmCateInfoResp.VmInfo.MaxDataDiskCount))
+				}
+
+				if newVolumeConfig["vol_number"].(int) < 1 {
+					return diag.FromErr(fmt.Errorf("the minimum allowed `vol_number` is: 1"))
+				}
+
+				if v, ok := newVolumeConfig["vol_number"]; ok {
+					scaleReq.VmVolNum = int64(v.(int))
+				}
+				if v, ok := newVolumeConfig["vol_size"]; ok {
+					scaleReq.VmVolSize = int64(v.(int))
+				}
+				if v, ok := newVolumeConfig["iops"]; ok {
+					scaleReq.Iops = int64(v.(int))
+				}
+				if v, ok := newVolumeConfig["throughput"]; ok {
+					scaleReq.Throughput = int64(v.(int))
+				}
+			}
+
+			resp, err := clusterAPI.ScaleWarehouseSize(ctx, scaleReq)
+
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("failed to scale warehouse size, clusterId:%s warehouseId:%s, errMsg:%s", clusterId, warehouseId, err))
+			}
+
+			stateResp, err := WaitClusterStateChangeComplete(ctx, &waitStateReq{
+				clusterAPI: clusterAPI,
+				actionID:   resp.ActionID,
+				clusterID:  clusterId,
+				timeout:    common.DeployOrScaleClusterTimeout,
+				pendingStates: []string{
+					string(cluster.ClusterStateRunning),
+					string(cluster.ClusterStateScaling)},
+				targetStates: []string{string(cluster.ClusterStateRunning), string(cluster.ClusterStateAbnormal)},
+			})
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("waiting for cluster (%s) running: %s", clusterId, err))
+			}
+
+			if stateResp.ClusterState == string(cluster.ClusterStateAbnormal) {
+				return diag.FromErr(errors.New(stateResp.AbnormalReason))
+			}
+		}
+	} else if req.customAmiChanged {
+		// Upgrade warehouse AMI when size is unchanged
+		_, nAmi := req.d.GetChange("custom_ami.0.ami")
+		_, nOs := req.d.GetChange("custom_ami.0.os")
+		if err := upgradeAMI(ctx, clusterAPI, &cluster.UpgradeAMIReq{
+			ClusterId:   clusterId,
+			Os:          nOs.(string),
+			Ami:         nAmi.(string),
 			WarehouseId: warehouseId,
-			VmCate:      vmCate,
-		}
-
-		if computeNodeIsInstanceStore && !vmCateInfoResp.VmInfo.IsInstanceStore {
-			newVolumeConfig := cluster.DefaultBeVolumeMap()
-			if len(newParamMap["compute_node_volume_config"].([]interface{})) > 0 {
-				newVolumeConfig = newParamMap["compute_node_volume_config"].([]interface{})[0].(map[string]interface{})
-			}
-
-			if newVolumeConfig["vol_number"].(int) > int(vmCateInfoResp.VmInfo.MaxDataDiskCount) {
-				return diag.FromErr(fmt.Errorf("the maximum allowed `vol_number` for this VM type is: %d", vmCateInfoResp.VmInfo.MaxDataDiskCount))
-			}
-
-			if newVolumeConfig["vol_number"].(int) < 1 {
-				return diag.FromErr(fmt.Errorf("the minimum allowed `vol_number` is: 1"))
-			}
-
-			if v, ok := newVolumeConfig["vol_number"]; ok {
-				scaleReq.VmVolNum = int64(v.(int))
-			}
-			if v, ok := newVolumeConfig["vol_size"]; ok {
-				scaleReq.VmVolSize = int64(v.(int))
-			}
-			if v, ok := newVolumeConfig["iops"]; ok {
-				scaleReq.Iops = int64(v.(int))
-			}
-			if v, ok := newVolumeConfig["throughput"]; ok {
-				scaleReq.Throughput = int64(v.(int))
-			}
-		}
-
-		resp, err := clusterAPI.ScaleWarehouseSize(ctx, scaleReq)
-
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("failed to scale warehouse size, clusterId:%s warehouseId:%s, errMsg:%s", clusterId, warehouseId, err))
-		}
-
-		stateResp, err := WaitClusterStateChangeComplete(ctx, &waitStateReq{
-			clusterAPI: clusterAPI,
-			actionID:   resp.ActionID,
-			clusterID:  clusterId,
-			timeout:    common.DeployOrScaleClusterTimeout,
-			pendingStates: []string{
-				string(cluster.ClusterStateRunning),
-				string(cluster.ClusterStateScaling)},
-			targetStates: []string{string(cluster.ClusterStateRunning), string(cluster.ClusterStateAbnormal)},
-		})
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("waiting for cluster (%s) running: %s", clusterId, err))
-		}
-
-		if stateResp.ClusterState == string(cluster.ClusterStateAbnormal) {
-			return diag.FromErr(errors.New(stateResp.AbnormalReason))
-		}
-	}
-
-	// Modify warehouse node count
-	computeNodeCountChanged := oldParamMap["compute_node_count"].(int) != newParamMap["compute_node_count"].(int)
-	if computeNodeCountChanged {
-		vmNum := int32(newParamMap["compute_node_count"].(int))
-		resp, err := clusterAPI.ScaleWarehouseNum(ctx, &cluster.ScaleWarehouseNumReq{
-			WarehouseId: warehouseId,
-			VmNum:       vmNum,
-		})
-
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("failed to scale warehouse number, clusterId:%s warehouseId:%s, errMsg:%s", clusterId, warehouseId, err))
-		}
-
-		stateResp, err := WaitClusterStateChangeComplete(ctx, &waitStateReq{
-			clusterAPI: clusterAPI,
-			actionID:   resp.ActionID,
-			clusterID:  clusterId,
-			timeout:    common.DeployOrScaleClusterTimeout,
-			pendingStates: []string{
-				string(cluster.ClusterStateRunning),
-				string(cluster.ClusterStateScaling)},
-			targetStates: []string{string(cluster.ClusterStateRunning), string(cluster.ClusterStateAbnormal)},
-		})
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("waiting for cluster (%s) running: %s", clusterId, err))
-		}
-
-		if stateResp.ClusterState == string(cluster.ClusterStateAbnormal) {
-			return diag.FromErr(errors.New(stateResp.AbnormalReason))
+			ModuleType:  cluster.ClusterModuleTypeWarehouse,
+		}); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 
@@ -2826,7 +2530,7 @@ func updateWarehouse(ctx context.Context, req *UpdateWarehouseReq, multiAz bool)
 		// Modidy warehouse state
 		if expectedStateChanged {
 			if expectedState == string(cluster.ClusterStateSuspended) {
-				resp := SuspendWarehouse(ctx, clusterAPI, clusterId, warehouseId, warehouseName)
+				resp := suspendWarehouse(ctx, clusterAPI, clusterId, warehouseId, warehouseName)
 				if resp != nil {
 					return resp
 				}
@@ -2876,7 +2580,7 @@ func updateWarehouse(ctx context.Context, req *UpdateWarehouseReq, multiAz bool)
 	return nil
 }
 
-func DeleteWarehouse(ctx context.Context, clusterAPI cluster.IClusterAPI, clusterId, warehouseId string) (diags diag.Diagnostics) {
+func deleteWarehouse(ctx context.Context, clusterAPI cluster.IClusterAPI, clusterId, warehouseId string) (diags diag.Diagnostics) {
 
 	resp, err := clusterAPI.ReleaseWarehouse(ctx, &cluster.ReleaseWarehouseReq{
 		WarehouseId: warehouseId,
@@ -2921,7 +2625,7 @@ func DeleteWarehouse(ctx context.Context, clusterAPI cluster.IClusterAPI, cluste
 	return diags
 }
 
-func SuspendWarehouse(ctx context.Context, clusterAPI cluster.IClusterAPI, clusterId, warehouseId, warehouseName string) (diags diag.Diagnostics) {
+func suspendWarehouse(ctx context.Context, clusterAPI cluster.IClusterAPI, clusterId, warehouseId, warehouseName string) (diags diag.Diagnostics) {
 	suspendWhResp, err := clusterAPI.SuspendWarehouse(ctx, &cluster.SuspendWarehouseReq{
 		WarehouseId: warehouseId,
 	})
@@ -2980,7 +2684,7 @@ func SuspendWarehouse(ctx context.Context, clusterAPI cluster.IClusterAPI, clust
 	return diags
 }
 
-func ResumeWarehouse(ctx context.Context, clusterAPI cluster.IClusterAPI, clusterId, warehouseId, warehouseName string) (diags diag.Diagnostics) {
+func resumeWarehouse(ctx context.Context, clusterAPI cluster.IClusterAPI, clusterId, warehouseId, warehouseName string) (diags diag.Diagnostics) {
 	resumeWhResp, err := clusterAPI.ResumeWarehouse(ctx, &cluster.ResumeWarehouseReq{
 		WarehouseId: warehouseId,
 	})
@@ -3027,7 +2731,7 @@ func ResumeWarehouse(ctx context.Context, clusterAPI cluster.IClusterAPI, cluste
 	return diags
 }
 
-func IsAllRunning(c *cluster.Cluster) bool {
+func isAllRunning(c *cluster.Cluster) bool {
 	if c.ClusterState != cluster.ClusterStateRunning {
 		return false
 	}
@@ -3042,12 +2746,672 @@ func IsAllRunning(c *cluster.Cluster) bool {
 }
 
 type UpdateWarehouseReq struct {
-	d              *schema.ResourceData
-	clusterAPI     cluster.IClusterAPI
-	clusterId      string
-	oldParamMap    map[string]interface{}
-	newParamMap    map[string]interface{}
-	whExternalInfo *cluster.WarehouseExternalInfo
+	d                *schema.ResourceData
+	clusterAPI       cluster.IClusterAPI
+	clusterId        string
+	oldParamMap      map[string]interface{}
+	newParamMap      map[string]interface{}
+	whExternalInfo   *cluster.WarehouseExternalInfo
+	customAmiChanged bool
+}
+
+func handleLdapSslCertsChange(ctx context.Context, d *schema.ResourceData, clusterAPI cluster.IClusterAPI) diag.Diagnostics {
+	sslCerts := make([]string, 0)
+	if v, ok := d.GetOk("ldap_ssl_certs"); ok {
+		arr := v.(*schema.Set).List()
+		for _, v := range arr {
+			sslCerts = append(sslCerts, v.(string))
+		}
+	}
+	warningDiag := UpsertClusterLdapSslCert(ctx, clusterAPI, d.Id(), sslCerts, true)
+	if warningDiag != nil {
+		return warningDiag
+	}
+	return nil
+}
+
+func handleClusterResourceTagsChange(ctx context.Context, d *schema.ResourceData, clusterAPI cluster.IClusterAPI, clusterId string) diag.Diagnostics {
+	_, n := d.GetChange("resource_tags")
+
+	nTags := n.(map[string]interface{})
+	tags := make(map[string]string, len(nTags))
+	for k, v := range nTags {
+		tags[k] = v.(string)
+	}
+
+	err := clusterAPI.UpdateResourceTags(ctx, &cluster.UpdateResourceTagsReq{
+		ClusterId: clusterId,
+		Tags:      tags,
+	})
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("cluster (%s) failed to update resource tags: %s", d.Id(), err.Error()))
+	}
+	return nil
+}
+
+func handleInitScriptsChange(ctx context.Context, d *schema.ResourceData, clusterAPI cluster.IClusterAPI, clusterId string) diag.Diagnostics {
+	_, n := d.GetChange("init_scripts")
+	vL := n.(*schema.Set).List()
+
+	scripts := make([]*cluster.Script, 0, len(vL))
+	for _, v := range vL {
+		s := v.(map[string]interface{})
+		scripts = append(scripts, &cluster.Script{
+			ScriptPath: s["script_path"].(string),
+			LogsDir:    s["logs_dir"].(string),
+		})
+	}
+
+	err := clusterAPI.UpdateDeploymentScripts(ctx, &cluster.UpdateDeploymentScriptsReq{
+		ClusterId: clusterId,
+		Scripts:   scripts,
+		Parallel:  d.Get("run_scripts_parallel").(bool),
+		Timeout:   int32(d.Get("run_scripts_timeout").(int)),
+	})
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("failed to update cluster(%s) init-scripts: %s", d.Id(), err.Error()))
+	}
+	return nil
+}
+
+func handleFEScaleUp(ctx context.Context, d *schema.ResourceData, clusterAPI cluster.IClusterAPI, clusterId string) diag.Diagnostics {
+	_, n := d.GetChange("coordinator_node_size")
+
+	resp, err := clusterAPI.ScaleUp(ctx, &cluster.ScaleUpReq{
+		RequestId:  uuid.NewString(),
+		ClusterId:  clusterId,
+		ModuleType: cluster.ClusterModuleTypeFE,
+		VmCategory: n.(string),
+	})
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("cluster (%s) failed to scale up coordinator nodes: %s", d.Id(), err))
+	}
+
+	stateResp, err := WaitClusterStateChangeComplete(ctx, &waitStateReq{
+		clusterAPI:    clusterAPI,
+		actionID:      resp.ActionId,
+		clusterID:     clusterId,
+		timeout:       common.DeployOrScaleClusterTimeout,
+		pendingStates: []string{string(cluster.ClusterStateScaling)},
+		targetStates:  []string{string(cluster.ClusterStateRunning), string(cluster.ClusterStateAbnormal)},
+	})
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("waiting for cluster (%s) running %s", d.Id(), err))
+	}
+
+	if stateResp.ClusterState == string(cluster.ClusterStateAbnormal) {
+		return diag.FromErr(errors.New(stateResp.AbnormalReason))
+	}
+
+	return nil
+}
+
+func handleFEScaleUpAndUpgradeAMI(ctx context.Context, d *schema.ResourceData, clusterAPI cluster.IClusterAPI, clusterId string) diag.Diagnostics {
+	_, nSize := d.GetChange("coordinator_node_size")
+	_, nAmi := d.GetChange("custom_ami.0.ami")
+	_, nOs := d.GetChange("custom_ami.0.os")
+
+	resp, err := clusterAPI.ScaleUpFEAndUpgradeAMI(ctx, &cluster.ScaleUpFEAndUpgradeAMIReq{
+		RequestId:  uuid.NewString(),
+		ClusterId:  clusterId,
+		VmCategory: nSize.(string),
+		Ami:        nAmi.(string),
+		Os:         nOs.(string),
+	})
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("cluster (%s) failed to scale up FE and upgrade AMI: %s", d.Id(), err))
+	}
+
+	stateResp, err := WaitClusterStateChangeComplete(ctx, &waitStateReq{
+		clusterAPI:    clusterAPI,
+		actionID:      resp.ActionId,
+		clusterID:     clusterId,
+		timeout:       common.DeployOrScaleClusterTimeout,
+		pendingStates: []string{string(cluster.ClusterStateScaling)},
+		targetStates:  []string{string(cluster.ClusterStateRunning), string(cluster.ClusterStateAbnormal)},
+	})
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("waiting for cluster (%s) running: %s", d.Id(), err))
+	}
+
+	if stateResp.ClusterState == string(cluster.ClusterStateAbnormal) {
+		return diag.FromErr(errors.New(stateResp.AbnormalReason))
+	}
+
+	return nil
+}
+
+func handleFEScaleIn(ctx context.Context, d *schema.ResourceData, clusterAPI cluster.IClusterAPI, clusterId string) diag.Diagnostics {
+	o, n := d.GetChange("coordinator_node_count")
+	if n.(int) >= o.(int) {
+		return nil
+	}
+
+	resp, err := clusterAPI.ScaleIn(ctx, &cluster.ScaleInReq{
+		RequestId:  uuid.NewString(),
+		ClusterId:  clusterId,
+		ModuleType: cluster.ClusterModuleTypeFE,
+		ExpectNum:  int32(n.(int)),
+	})
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("cluster (%s) failed to scale in fe nodes: %s", d.Id(), err))
+	}
+
+	stateResp, err := WaitClusterStateChangeComplete(ctx, &waitStateReq{
+		clusterAPI:    clusterAPI,
+		actionID:      resp.ActionId,
+		clusterID:     clusterId,
+		timeout:       common.DeployOrScaleClusterTimeout,
+		pendingStates: []string{string(cluster.ClusterStateScaling)},
+		targetStates:  []string{string(cluster.ClusterStateRunning), string(cluster.ClusterStateAbnormal)},
+	})
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("waiting for cluster (%s) running: %s", d.Id(), err))
+	}
+
+	if stateResp.ClusterState == string(cluster.ClusterStateAbnormal) {
+		return diag.FromErr(errors.New(stateResp.AbnormalReason))
+	}
+
+	return nil
+}
+
+func handleFEScaleOut(ctx context.Context, d *schema.ResourceData, clusterAPI cluster.IClusterAPI, clusterId string) diag.Diagnostics {
+	o, n := d.GetChange("coordinator_node_count")
+	if n.(int) <= o.(int) {
+		return nil
+	}
+
+	resp, err := clusterAPI.ScaleOut(ctx, &cluster.ScaleOutReq{
+		RequestId:  uuid.NewString(),
+		ClusterId:  clusterId,
+		ModuleType: cluster.ClusterModuleTypeFE,
+		ExpectNum:  int32(n.(int)),
+	})
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("cluster (%s) failed to scale out fe nodes: %s", d.Id(), err))
+	}
+
+	stateResp, err := WaitClusterStateChangeComplete(ctx, &waitStateReq{
+		clusterAPI:    clusterAPI,
+		actionID:      resp.ActionId,
+		clusterID:     clusterId,
+		timeout:       common.DeployOrScaleClusterTimeout,
+		pendingStates: []string{string(cluster.ClusterStateScaling)},
+		targetStates:  []string{string(cluster.ClusterStateRunning), string(cluster.ClusterStateAbnormal)},
+	})
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("waiting for cluster (%s) running: %s", d.Id(), err))
+	}
+
+	if stateResp.ClusterState == string(cluster.ClusterStateAbnormal) {
+		return diag.FromErr(errors.New(stateResp.AbnormalReason))
+	}
+
+	return nil
+}
+
+func handleFEVolumeConfigChange(ctx context.Context, d *schema.ResourceData, clusterAPI cluster.IClusterAPI, clusterId string) diag.Diagnostics {
+	o, n := d.GetChange("coordinator_node_volume_config")
+
+	oldVolumeConfig, newVolumeConfig := cluster.DefaultFeVolumeMap(), cluster.DefaultFeVolumeMap()
+
+	if len(o.([]interface{})) > 0 {
+		oldVolumeConfig = o.([]interface{})[0].(map[string]interface{})
+	}
+	if len(n.([]interface{})) > 0 {
+		newVolumeConfig = n.([]interface{})[0].(map[string]interface{})
+	}
+
+	nodeType := cluster.ClusterModuleTypeFE
+	req := &cluster.ModifyClusterVolumeReq{
+		ClusterId: clusterId,
+		Type:      nodeType,
+	}
+
+	if v, ok := newVolumeConfig["vol_size"]; ok && v != oldVolumeConfig["vol_size"] {
+		req.VmVolSize = int64(v.(int))
+	}
+	if v, ok := newVolumeConfig["iops"]; ok && v != oldVolumeConfig["iops"] {
+		req.Iops = int64(v.(int))
+	}
+	if v, ok := newVolumeConfig["throughput"]; ok && v != oldVolumeConfig["throughput"] {
+		req.Throughput = int64(v.(int))
+	}
+
+	log.Printf("[DEBUG] modify cluster volume detail, req:%+v", req)
+	resp, err := clusterAPI.ModifyClusterVolume(ctx, req)
+	if err != nil {
+		log.Printf("[ERROR] modify cluster volume detail failed, err:%+v", err)
+		return diag.FromErr(err)
+	}
+
+	infraActionId := resp.ActionID
+	if len(infraActionId) == 0 {
+		return nil
+	}
+
+	infraActionResp, err := WaitClusterInfraActionStateChangeComplete(ctx, &waitStateReq{
+		clusterAPI: clusterAPI,
+		clusterID:  clusterId,
+		actionID:   infraActionId,
+		timeout:    30 * time.Minute,
+		pendingStates: []string{
+			string(cluster.ClusterInfraActionStatePending),
+			string(cluster.ClusterInfraActionStateOngoing),
+		},
+		targetStates: []string{
+			string(cluster.ClusterInfraActionStateSucceeded),
+			string(cluster.ClusterInfraActionStateCompleted),
+			string(cluster.ClusterInfraActionStateFailed),
+		},
+	})
+
+	summary := fmt.Sprintf("Modify %s node volume detail of the cluster[%s] failed", nodeType, clusterId)
+	if err != nil {
+		return diag.Diagnostics{{
+			Severity: diag.Error,
+			Summary:  summary,
+			Detail:   err.Error(),
+		}}
+	}
+
+	if infraActionResp.InfraActionState == string(cluster.ClusterInfraActionStateFailed) {
+		return diag.Diagnostics{{
+			Severity: diag.Error,
+			Summary:  summary,
+			Detail:   infraActionResp.ErrMsg,
+		}}
+	}
+
+	return nil
+}
+
+func handleCoordinatorNodeConfigsChange(ctx context.Context, d *schema.ResourceData, clusterAPI cluster.IClusterAPI, clusterId string) diag.Diagnostics {
+	configMap := d.Get("coordinator_node_configs").(map[string]interface{})
+	configs := make(map[string]string, 0)
+	for k, v := range configMap {
+		configs[k] = v.(string)
+	}
+
+	warnDiag := UpsertClusterConfig(ctx, clusterAPI, &cluster.UpsertClusterConfigReq{
+		ClusterID:  clusterId,
+		ConfigType: cluster.CustomConfigTypeFE,
+		Configs:    configs,
+	})
+	if warnDiag != nil {
+		return warnDiag
+	}
+
+	return nil
+}
+
+func handleDefaultWarehouseChange(ctx context.Context, d *schema.ResourceData, clusterAPI cluster.IClusterAPI, clusterId string, multiAz bool, customAmiChanged bool) diag.Diagnostics {
+	if !d.HasChange("default_warehouse") && !customAmiChanged {
+		return nil
+	}
+
+	whExternalInfoMap := d.Get("warehouse_external_info").(map[string]interface{})
+
+	dOld, dNew := d.GetChange("default_warehouse")
+	oldWh := dOld.([]interface{})[0].(map[string]interface{})
+	newWh := dNew.([]interface{})[0].(map[string]interface{})
+	whExternalInfoStr := whExternalInfoMap[DEFAULT_WAREHOUSE_NAME].(string)
+	whExternalInfo := &cluster.WarehouseExternalInfo{}
+	json.Unmarshal([]byte(whExternalInfoStr), whExternalInfo)
+
+	diags := updateWarehouse(ctx, &UpdateWarehouseReq{
+		d:                d,
+		clusterAPI:       clusterAPI,
+		clusterId:        clusterId,
+		oldParamMap:      oldWh,
+		newParamMap:      newWh,
+		whExternalInfo:   whExternalInfo,
+		customAmiChanged: customAmiChanged,
+	}, multiAz)
+	if diags != nil {
+		return diags
+	}
+	return nil
+}
+
+func handleWarehousesChange(ctx context.Context, d *schema.ResourceData, clusterAPI cluster.IClusterAPI, clusterId string, multiAz bool, customAmiChanged bool) diag.Diagnostics {
+	if !d.HasChange("warehouse") && !customAmiChanged {
+		return nil
+	}
+
+	o, n := d.GetChange("warehouse")
+	old := o.([]interface{})
+	newV := n.([]interface{})
+	whExternalInfoMap := d.Get("warehouse_external_info").(map[string]interface{})
+
+	oldWhMap := make(map[string]map[string]interface{})
+	for _, v := range old {
+		whMap := v.(map[string]interface{})
+		oldWhMap[whMap["name"].(string)] = whMap
+	}
+
+	for _, v := range newV {
+		newWh := v.(map[string]interface{})
+		whName := newWh["name"].(string)
+		if oldWh, ok := oldWhMap[whName]; ok {
+			whExternalInfoStr := whExternalInfoMap[whName].(string)
+			whExternalInfo := &cluster.WarehouseExternalInfo{}
+			json.Unmarshal([]byte(whExternalInfoStr), whExternalInfo)
+
+			diags := updateWarehouse(ctx, &UpdateWarehouseReq{
+				d:                d,
+				clusterAPI:       clusterAPI,
+				clusterId:        clusterId,
+				oldParamMap:      oldWh,
+				newParamMap:      newWh,
+				whExternalInfo:   whExternalInfo,
+				customAmiChanged: customAmiChanged,
+			}, multiAz)
+			if diags != nil {
+				return diags
+			}
+		}
+	}
+
+	return nil
+}
+
+func handleScaleOutWarehouses(ctx context.Context, d *schema.ResourceData, clusterAPI cluster.IClusterAPI, clusterId string) diag.Diagnostics {
+	return handleScaleWarehouses(ctx, d, clusterAPI, clusterId, true)
+}
+
+func handleScaleInWarehouses(ctx context.Context, d *schema.ResourceData, clusterAPI cluster.IClusterAPI, clusterId string) diag.Diagnostics {
+	return handleScaleWarehouses(ctx, d, clusterAPI, clusterId, false)
+}
+
+func handleScaleWarehouses(ctx context.Context, d *schema.ResourceData, clusterAPI cluster.IClusterAPI, clusterId string, isScaleOut bool) diag.Diagnostics {
+	if !d.HasChange("warehouse") && !d.HasChange("default_warehouse") {
+		return nil
+	}
+
+	whExternalInfoMap := d.Get("warehouse_external_info").(map[string]interface{})
+
+	if d.HasChange("warehouse") {
+		o, n := d.GetChange("warehouse")
+		old := o.([]interface{})
+		newV := n.([]interface{})
+		oldWhMap := make(map[string]map[string]interface{})
+		for _, v := range old {
+			whMap := v.(map[string]interface{})
+			oldWhMap[whMap["name"].(string)] = whMap
+		}
+
+		for _, v := range newV {
+			newWh := v.(map[string]interface{})
+			whName := newWh["name"].(string)
+			oldWh, ok := oldWhMap[whName]
+			if !ok {
+				continue
+			}
+			whExternalInfoStr := whExternalInfoMap[whName].(string)
+			whExternalInfo := &cluster.WarehouseExternalInfo{}
+			json.Unmarshal([]byte(whExternalInfoStr), whExternalInfo)
+			oldCnt := oldWh["compute_node_count"].(int)
+			newCnt := newWh["compute_node_count"].(int)
+			if (isScaleOut && newCnt > oldCnt) || (!isScaleOut && newCnt < oldCnt) {
+				if err := scaleWarehouseNum(ctx, clusterAPI, clusterId, whExternalInfo.Id, int32(newCnt)); err != nil {
+					return diag.FromErr(err)
+				}
+			}
+		}
+	}
+
+	if d.HasChange("default_warehouse") {
+		defaultOld, defaultNew := d.GetChange("default_warehouse")
+		defaultOldWh := defaultOld.([]interface{})[0].(map[string]interface{})
+		defaultNewWh := defaultNew.([]interface{})[0].(map[string]interface{})
+
+		defaultWhExternalInfoStr := whExternalInfoMap[DEFAULT_WAREHOUSE_NAME].(string)
+		defaultWhExternalInfo := &cluster.WarehouseExternalInfo{}
+		json.Unmarshal([]byte(defaultWhExternalInfoStr), defaultWhExternalInfo)
+
+		defaultOldCnt := defaultOldWh["compute_node_count"].(int)
+		defaultNewCnt := defaultNewWh["compute_node_count"].(int)
+		if (isScaleOut && defaultNewCnt > defaultOldCnt) || (!isScaleOut && defaultNewCnt < defaultOldCnt) {
+			if err := scaleWarehouseNum(ctx, clusterAPI, clusterId, defaultWhExternalInfo.Id, int32(defaultNewCnt)); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func scaleWarehouseNum(ctx context.Context, clusterAPI cluster.IClusterAPI, clusterId, warehouseId string, vmNum int32) error {
+	resp, err := clusterAPI.ScaleWarehouseNum(ctx, &cluster.ScaleWarehouseNumReq{
+		WarehouseId: warehouseId,
+		VmNum:       vmNum,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to scale warehouse number, clusterId:%s warehouseId:%s, errMsg:%s", clusterId, warehouseId, err)
+	}
+
+	stateResp, err := WaitClusterStateChangeComplete(ctx, &waitStateReq{
+		clusterAPI: clusterAPI,
+		actionID:   resp.ActionID,
+		clusterID:  clusterId,
+		timeout:    common.DeployOrScaleClusterTimeout,
+		pendingStates: []string{
+			string(cluster.ClusterStateRunning),
+			string(cluster.ClusterStateScaling)},
+		targetStates: []string{string(cluster.ClusterStateRunning), string(cluster.ClusterStateAbnormal)},
+	})
+	if err != nil {
+		return fmt.Errorf("waiting for cluster (%s) running: %s", clusterId, err)
+	}
+
+	if stateResp.ClusterState == string(cluster.ClusterStateAbnormal) {
+		return errors.New(stateResp.AbnormalReason)
+	}
+	return nil
+}
+
+func handleResumeWarehouses(ctx context.Context, d *schema.ResourceData, clusterAPI cluster.IClusterAPI, clusterId string) diag.Diagnostics {
+	if !d.HasChange("warehouse") {
+		return nil
+	}
+
+	o, n := d.GetChange("warehouse")
+	old := o.([]interface{})
+	newV := n.([]interface{})
+
+	oldWhMap := make(map[string]map[string]interface{})
+	for _, v := range old {
+		whMap := v.(map[string]interface{})
+		oldWhMap[whMap["name"].(string)] = whMap
+	}
+
+	whExternalInfoMap := d.Get("warehouse_external_info").(map[string]interface{})
+
+	for _, v := range newV {
+		newWh := v.(map[string]interface{})
+		whName := newWh["name"].(string)
+
+		oldWh, ok := oldWhMap[whName]
+		if !ok {
+			continue
+		}
+		whExternalInfoStr := whExternalInfoMap[whName].(string)
+		whExternalInfo := &cluster.WarehouseExternalInfo{}
+		json.Unmarshal([]byte(whExternalInfoStr), whExternalInfo)
+
+		if whExternalInfo.IsDefaultWarehouse {
+			continue
+		}
+
+		expectedStateChanged := oldWh["expected_state"].(string) != newWh["expected_state"].(string)
+		if expectedStateChanged && newWh["expected_state"].(string) == string(cluster.ClusterStateRunning) {
+			diags := resumeWarehouse(ctx, clusterAPI, clusterId, whExternalInfo.Id, whName)
+			if diags != nil {
+				return diags
+			}
+		}
+	}
+
+	return nil
+}
+
+func handleDeleteWarehouses(ctx context.Context, d *schema.ResourceData, clusterAPI cluster.IClusterAPI, clusterId string) diag.Diagnostics {
+	if !d.HasChange("warehouse") {
+		return nil
+	}
+
+	o, n := d.GetChange("warehouse")
+	old := o.([]interface{})
+	newV := n.([]interface{})
+	whExternalInfoMap := d.Get("warehouse_external_info").(map[string]interface{})
+
+	newWhMap := make(map[string]map[string]interface{})
+	for _, v := range newV {
+		whMap := v.(map[string]interface{})
+		newWhMap[whMap["name"].(string)] = whMap
+	}
+
+	for _, v := range old {
+		oldWh := v.(map[string]interface{})
+		whName := oldWh["name"].(string)
+		if _, ok := newWhMap[whName]; ok {
+			continue
+		}
+		whExternalInfoStr := whExternalInfoMap[whName].(string)
+		whExternalInfo := &cluster.WarehouseExternalInfo{}
+		json.Unmarshal([]byte(whExternalInfoStr), whExternalInfo)
+
+		diags := deleteWarehouse(ctx, clusterAPI, clusterId, whExternalInfo.Id)
+		if diags != nil {
+			return diags
+		}
+	}
+
+	return nil
+}
+
+func handleCreateWarehouses(ctx context.Context, d *schema.ResourceData, clusterAPI cluster.IClusterAPI, clusterId string) diag.Diagnostics {
+	if !d.HasChange("warehouse") {
+		return nil
+	}
+
+	o, n := d.GetChange("warehouse")
+	old := o.([]interface{})
+	newV := n.([]interface{})
+
+	oldWhMap := make(map[string]map[string]interface{})
+	for _, v := range old {
+		whMap := v.(map[string]interface{})
+		oldWhMap[whMap["name"].(string)] = whMap
+	}
+
+	for _, v := range newV {
+		newWh := v.(map[string]interface{})
+		whName := newWh["name"].(string)
+		if _, ok := oldWhMap[whName]; ok {
+			continue
+		}
+		diags := createWarehouse(ctx, clusterAPI, clusterId, newWh)
+		if diags != nil {
+			return diags
+		}
+	}
+
+	return nil
+}
+
+func handleRangerConfigIDChange(ctx context.Context, d *schema.ResourceData, clusterAPI cluster.IClusterAPI, clusterId string) diag.Diagnostics {
+	rangerConfigID := d.Get("ranger_config_id").(string)
+	var warningDiag diag.Diagnostics
+	if rangerConfigID == "" {
+		warningDiag = ClearRangerV2(ctx, clusterAPI, clusterId)
+	} else {
+		warningDiag = ApplyRangerV2(ctx, clusterAPI, clusterId, rangerConfigID)
+	}
+	if warningDiag != nil {
+		return warningDiag
+	}
+	return nil
+}
+
+func handleFECustomAmiChange(ctx context.Context, d *schema.ResourceData, clusterAPI cluster.IClusterAPI, clusterId string) diag.Diagnostics {
+	o, _ := d.GetChange("custom_ami")
+	if len(o.([]interface{})) == 0 {
+		return diag.FromErr(errors.New("custom ami can only be specified when creating cluster"))
+	}
+
+	if d.HasChange("custom_ami.0.os") && !d.IsNewResource() {
+		oOs, nOs := d.GetChange("custom_ami.0.os")
+		if len(oOs.(string)) > 0 && oOs.(string) != nOs.(string) {
+			return diag.FromErr(errors.New("custom ami os can not be changed"))
+		}
+	}
+
+	if !d.HasChange("custom_ami.0.ami") || d.IsNewResource() {
+		return nil
+	}
+
+	_, nAmi := d.GetChange("custom_ami.0.ami")
+	_, nOs := d.GetChange("custom_ami.0.os")
+
+	clusterResp, err := clusterAPI.Get(ctx, &cluster.GetReq{ClusterID: clusterId})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if !isAllRunning(clusterResp.Cluster) {
+		return diag.FromErr(errors.New("custom ami can only be upgraded when the cluster and all warehouse states are running"))
+	}
+
+	if err := upgradeAMI(ctx, clusterAPI, &cluster.UpgradeAMIReq{
+		ClusterId:  clusterId,
+		Os:         nOs.(string),
+		Ami:        nAmi.(string),
+		ModuleType: cluster.ClusterModuleTypeFE,
+	}); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func handleWarehouseScaleUpAndUpgradeAMI(ctx context.Context, d *schema.ResourceData, clusterAPI cluster.IClusterAPI, clusterId, warehouseId, vmCate string) error {
+	_, nAmi := d.GetChange("custom_ami.0.ami")
+	_, nOs := d.GetChange("custom_ami.0.os")
+
+	resp, err := clusterAPI.ScaleUpWarehouseAndUpgradeAMI(ctx, &cluster.ScaleUpWarehouseAndUpgradeAMIReq{
+		RequestId:   uuid.NewString(),
+		ClusterId:   clusterId,
+		WarehouseId: warehouseId,
+		VmCategory:  vmCate,
+		Ami:         nAmi.(string),
+		Os:          nOs.(string),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to scale up warehouse and upgrade AMI, clusterId:%s warehouseId:%s, errMsg:%s", clusterId, warehouseId, err)
+	}
+
+	stateResp, err := WaitClusterStateChangeComplete(ctx, &waitStateReq{
+		clusterAPI: clusterAPI,
+		actionID:   resp.ActionId,
+		clusterID:  clusterId,
+		timeout:    common.DeployOrScaleClusterTimeout,
+		pendingStates: []string{
+			string(cluster.ClusterStateRunning),
+			string(cluster.ClusterStateScaling)},
+		targetStates: []string{string(cluster.ClusterStateRunning), string(cluster.ClusterStateAbnormal)},
+	})
+	if err != nil {
+		return fmt.Errorf("waiting for cluster (%s) running: %s", clusterId, err)
+	}
+
+	if stateResp.ClusterState == string(cluster.ClusterStateAbnormal) {
+		return errors.New(stateResp.AbnormalReason)
+	}
+
+	return nil
 }
 
 func configArrowFlight(ctx context.Context, clusterAPI cluster.IClusterAPI, req *cluster.SetClusterArrowFlightReq) diag.Diagnostics {

--- a/celerdatabyoc/resource_elastic_cluster_v2.go
+++ b/celerdatabyoc/resource_elastic_cluster_v2.go
@@ -1768,31 +1768,6 @@ func resourceElasticClusterV2Update(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
-	if d.HasChange("enabled_termination_protection") && !d.IsNewResource() {
-		enabled := d.Get("enabled_termination_protection").(bool)
-		err := clusterAPI.SetClusterTerminationProtection(ctx, clusterId, &cluster.SetClusterTerminationProtectionReq{
-			Enabled: enabled,
-		})
-		if err != nil {
-			return diag.FromErr(fmt.Errorf("cluster (%s) failed to set termination protection: %s", d.Id(), err.Error()))
-		}
-	}
-
-	if d.HasChange("enabled_arrow_flight") && !d.IsNewResource() {
-		enabled := d.Get("enabled_arrow_flight").(bool)
-		diagnostics := configArrowFlight(ctx, clusterAPI, &cluster.SetClusterArrowFlightReq{
-			ClusterId: clusterId,
-			Enabled:   enabled,
-		})
-		if diagnostics != nil {
-			return diagnostics
-		}
-	}
-
-	if d.HasChange("table_name_case_insensitive") && !d.IsNewResource() {
-		return diag.FromErr(fmt.Errorf("`table_name_case_insensitive` of cluster (%s) cannot be modifeid after the cluster is created", d.Id()))
-	}
-
 	var diags diag.Diagnostics
 	if needResume(d) {
 		o, n := d.GetChange("expected_cluster_state")
@@ -1862,6 +1837,31 @@ func resourceElasticClusterV2Update(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
+	if d.HasChange("enabled_termination_protection") && !d.IsNewResource() {
+		enabled := d.Get("enabled_termination_protection").(bool)
+		err := clusterAPI.SetClusterTerminationProtection(ctx, clusterId, &cluster.SetClusterTerminationProtectionReq{
+			Enabled: enabled,
+		})
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("cluster (%s) failed to set termination protection: %s", d.Id(), err.Error()))
+		}
+	}
+
+	if d.HasChange("enabled_arrow_flight") && !d.IsNewResource() {
+		enabled := d.Get("enabled_arrow_flight").(bool)
+		diagnostics := configArrowFlight(ctx, clusterAPI, &cluster.SetClusterArrowFlightReq{
+			ClusterId: clusterId,
+			Enabled:   enabled,
+		})
+		if diagnostics != nil {
+			return diagnostics
+		}
+	}
+
+	if d.HasChange("table_name_case_insensitive") && !d.IsNewResource() {
+		return diag.FromErr(fmt.Errorf("`table_name_case_insensitive` of cluster (%s) cannot be modifeid after the cluster is created", d.Id()))
+	}
+
 	if d.HasChange("coordinator_node_volume_config") {
 		if diags := handleFEVolumeConfigChange(ctx, d, clusterAPI, clusterId); diags != nil {
 			return diags
@@ -1925,6 +1925,10 @@ func resourceElasticClusterV2Update(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if diags := handleScaleOutWarehouses(ctx, d, clusterAPI, clusterId); diags != nil {
+		return diags
+	}
+
+	if diags := handleSuspendWarehouses(ctx, d, clusterAPI, clusterId); diags != nil {
 		return diags
 	}
 
@@ -2521,20 +2525,6 @@ func updateWarehouse(ctx context.Context, req *UpdateWarehouseReq, multiAz bool)
 		})
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("warehouse (%s) failed to update resource tags: %s", warehouseId, err.Error()))
-		}
-	}
-
-	if !isDefaultWarehouse {
-		expectedState := newParamMap["expected_state"].(string)
-		expectedStateChanged := oldParamMap["expected_state"].(string) != newParamMap["expected_state"].(string)
-		// Modidy warehouse state
-		if expectedStateChanged {
-			if expectedState == string(cluster.ClusterStateSuspended) {
-				resp := suspendWarehouse(ctx, clusterAPI, clusterId, warehouseId, warehouseName)
-				if resp != nil {
-					return resp
-				}
-			}
 		}
 	}
 
@@ -3248,6 +3238,51 @@ func handleResumeWarehouses(ctx context.Context, d *schema.ResourceData, cluster
 		expectedStateChanged := oldWh["expected_state"].(string) != newWh["expected_state"].(string)
 		if expectedStateChanged && newWh["expected_state"].(string) == string(cluster.ClusterStateRunning) {
 			diags := resumeWarehouse(ctx, clusterAPI, clusterId, whExternalInfo.Id, whName)
+			if diags != nil {
+				return diags
+			}
+		}
+	}
+
+	return nil
+}
+
+func handleSuspendWarehouses(ctx context.Context, d *schema.ResourceData, clusterAPI cluster.IClusterAPI, clusterId string) diag.Diagnostics {
+	if !d.HasChange("warehouse") {
+		return nil
+	}
+
+	o, n := d.GetChange("warehouse")
+	old := o.([]interface{})
+	newV := n.([]interface{})
+
+	oldWhMap := make(map[string]map[string]interface{})
+	for _, v := range old {
+		whMap := v.(map[string]interface{})
+		oldWhMap[whMap["name"].(string)] = whMap
+	}
+
+	whExternalInfoMap := d.Get("warehouse_external_info").(map[string]interface{})
+
+	for _, v := range newV {
+		newWh := v.(map[string]interface{})
+		whName := newWh["name"].(string)
+
+		oldWh, ok := oldWhMap[whName]
+		if !ok {
+			continue
+		}
+		whExternalInfoStr := whExternalInfoMap[whName].(string)
+		whExternalInfo := &cluster.WarehouseExternalInfo{}
+		json.Unmarshal([]byte(whExternalInfoStr), whExternalInfo)
+
+		if whExternalInfo.IsDefaultWarehouse {
+			continue
+		}
+
+		expectedStateChanged := oldWh["expected_state"].(string) != newWh["expected_state"].(string)
+		if expectedStateChanged && newWh["expected_state"].(string) == string(cluster.ClusterStateSuspended) {
+			diags := suspendWarehouse(ctx, clusterAPI, clusterId, whExternalInfo.Id, whName)
 			if diags != nil {
 				return diags
 			}


### PR DESCRIPTION
… scale-up with AMI upgrade

Restructure resourceElasticClusterV2Update into explicit REDUCE / CONFIG / MODIFY / ADD phases so reductions (FE scale-in, warehouse delete, warehouse scale-in) always run before config changes and new resources. Extract ~17 handleXxx helpers out of the monolithic update function and unexport Delete/Suspend/Resume/IsAllRunning helpers.

Add ScaleUpFEAndUpgradeAMI and ScaleUpWarehouseAndUpgradeAMI SDK endpoints and route FE / warehouse size changes through them when custom_ami.0.ami changes in the same apply, collapsing two sequential scale+AMI actions into one.