### PR TITLE
[Feature] Allow duplicate custom tag keys across cluster and warehouse

### DIFF
--- a/celerdatabyoc/resource_elastic_cluster_v2.go
+++ b/celerdatabyoc/resource_elastic_cluster_v2.go
@@ -1031,18 +1031,14 @@ func customizeEl2Diff(ctx context.Context, d *schema.ResourceDiff, m interface{}
 		return fmt.Errorf("when modify `global_session_variables` [from %s to %s], field `expected_cluster_state` should change to:%s", o, n, cluster.ClusterStateRunning)
 	}
 
-	clusterTagSet := make(map[string]bool)
 	if v, ok := d.GetOk("resource_tags"); ok {
 		for k := range v.(map[string]interface{}) {
 			if IsInternalTagKeys(csp, k) {
 				return fmt.Errorf("cluster tag key %s is reserved for internal use and cannot be set", k)
 			}
-
-			clusterTagSet[k] = true
 		}
 	}
 
-	whTagSet := make(map[string]bool)
 	if v, ok := d.GetOk("default_warehouse"); ok {
 		defArr := v.([]interface{})
 		if len(defArr) > 0 {
@@ -1052,7 +1048,6 @@ func customizeEl2Diff(ctx context.Context, d *schema.ResourceDiff, m interface{}
 					if IsInternalTagKeys(csp, k) {
 						return fmt.Errorf("default warehouse tag key %s is reserved for internal use and cannot be set", k)
 					}
-					whTagSet[k] = true
 				}
 			}
 		}
@@ -1067,16 +1062,8 @@ func customizeEl2Diff(ctx context.Context, d *schema.ResourceDiff, m interface{}
 					if IsInternalTagKeys(csp, k) {
 						return fmt.Errorf("warehouse:%s tag key %s is reserved for internal use and cannot be set", whName, k)
 					}
-
-					whTagSet[k] = true
 				}
 			}
-		}
-	}
-
-	for k := range whTagSet {
-		if clusterTagSet[k] {
-			return fmt.Errorf("tag key %s is duplicated between cluster tags and warehouse tags", k)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Remove the cross-level duplicate-key validation in `resource_elastic_cluster_v2.go` so the same tag key can be declared at both cluster and warehouse levels.
- Per product requirement, customers need to reuse the same tag key (e.g. `env=prod` at cluster scope and `env=staging` on a specific warehouse).
- Reserved-key (internal AWS/Azure/GCP prefixes) validation is preserved.

## Semantics

Conflict resolution on shared tag keys is **last-write-wins**, not "warehouse always wins":

- **Single apply** changing both levels: provider flushes cluster tags first (`resource_elastic_cluster_v2.go:1807`) then warehouse tags (`1879` / `1883`), so warehouse is the last writer and its value lands on warehouse BE instances.
- **Two applies, warehouse first then cluster**: cluster-level update targets all VMs in the cluster (incl. warehouse BEs) and the cluster value overwrites the warehouse value physically on those BEs. The companion backend PR keeps the warehouse launchTemplate DB row synchronized with this outcome so future warehouse scale-out doesn't regress.

## Test plan

- [x] `go vet ./...` and `go build ./...` pass.
- [x] Stage E2E on AWS — `test_duplicate_key_across_cluster_and_wh_is_accepted` and `test_duplicate_key_warehouse_written_last_wins_on_wh_instances` pass; cluster auto-destroyed.
- [x] Reserved-key rejection (`test_internal_tags.py`) unaffected.

## Related

- Backend consistency fix: CelerDataInc/celerdata-byoc-cloud#7970
- E2E coverage: CelerData/celerdata-byoc-e2e#109
- The frontend Y/N confirmation UX ("This tag is used at the cluster (or warehouse) level. Using this again will overwrite the previous value. Do you want to proceed?") lives in a separate repo and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)