### PR TITLE
[Feature] Multi-AZ distribution policy support for warehouses

### DIFF
--- a/celerdata-sdk/service/cluster/entity.go
+++ b/celerdata-sdk/service/cluster/entity.go
@@ -779,7 +779,7 @@ type ChangeWarehouseDistributionReq struct {
 }
 
 type ChangeWarehouseDistributionResp struct {
-	ActionID string `json:"action_id" mapstructure:"action_id"`
+	InfraActionId string `json:"infra_action_id" mapstructure:"infra_action_id"`
 }
 
 type GetVmInfoReq struct {

--- a/celerdata-sdk/service/cluster/entity.go
+++ b/celerdata-sdk/service/cluster/entity.go
@@ -139,6 +139,7 @@ const (
 
 	DistributionPolicySpecifyAZ  DistributionPolicy = "specify_az"
 	DistributionPolicyCrossingAZ DistributionPolicy = "crossing_az"
+	DistributionPolicyMultiAZ    DistributionPolicy = "multi_az"
 
 	AutoScalingUnit_SINGLE   AutoScalingUnit = 0
 	AutoScalingUnit_CN_GROUP AutoScalingUnit = 1
@@ -168,6 +169,7 @@ type ClusterItem struct {
 	DiskInfo           *DiskInfo         `json:"disk_info"`
 	DistributionPolicy string            `json:"distribution_policy"`
 	SpecifyAZ          string            `json:"specify_az"`
+	SpecifiedAZs       []string          `json:"specified_azs"`
 	Tags               []*Kv             `json:"tags"`
 }
 
@@ -292,6 +294,8 @@ type Warehouse struct {
 	DistributionPolicyStr string            `json:"distribution_policy_str" mapstructure:"distribution_policy_str"`
 	SpecifyAZ             string            `json:"specify_az" mapstructure:"specify_az"`
 	SpecifiedAZs          []string          `json:"specified_azs" mapstructure:"specified_azs"`
+	CngroupCount          uint32            `json:"cngroup_count" mapstructure:"cngroup_count"`
+	CngroupSize           uint32            `json:"cngroup_size" mapstructure:"cngroup_size"`
 	ResumeWithCluster     bool              `json:"resume_with_cluster" mapstructure:"resume_with_cluster"`
 	Tags                  map[string]string `json:"tags" mapstructure:"tags"`
 }
@@ -620,9 +624,10 @@ type WarehouseInfo struct {
 	VmCate                string `json:"vm_cate" mapstructure:"vm_cate"`
 	VmVolSizeGB           int64  `json:"vm_vol_size_gb" mapstructure:"vm_vol_size_gb"`
 	VmVolNum              int32  `json:"vm_vol_num" mapstructure:"vm_vol_num"`
-	IsInstanceStore       bool   `json:"is_instance_store" mapstructure:"is_instance_store"`
-	DistributionPolicyStr string `json:"distribution_policy_str" mapstructure:"distribution_policy_str"`
-	SpecifyAZ             string `json:"specify_az" mapstructure:"specify_az"`
+	IsInstanceStore       bool     `json:"is_instance_store" mapstructure:"is_instance_store"`
+	DistributionPolicyStr string   `json:"distribution_policy_str" mapstructure:"distribution_policy_str"`
+	SpecifyAZ             string   `json:"specify_az" mapstructure:"specify_az"`
+	SpecifiedAZs          []string `json:"specified_azs" mapstructure:"specified_azs"`
 }
 
 type GetWarehouseResp struct {
@@ -630,19 +635,20 @@ type GetWarehouseResp struct {
 }
 
 type CreateWarehouseReq struct {
-	ClusterId          string `json:"cluster_id" mapstructure:"cluster_id"`
-	Name               string `json:"name" mapstructure:"name"`
-	Description        string `json:"description" mapstructure:"description"`
-	VmCate             string `json:"vm_cate" mapstructure:"vm_cate"`
-	VmNum              int32  `json:"vm_num" mapstructure:"vm_num"`
-	VolumeSizeGB       int64  `json:"volume_size_gb" mapstructure:"volume_size_gb"`
-	VolumeNum          int32  `json:"volume_num" mapstructure:"volume_num"`
-	DistributionPolicy string `json:"distribution_policy" mapstructure:"distribution_policy"`
-	SpecifyAZ          string `json:"specify_az" mapstructure:"specify_az"`
-	Iops               int64  `json:"iops" mapstructure:"iops"`
-	Throughput         int64  `json:"throughput" mapstructure:"throughput"`
-	ResumeWithCluster  bool   `json:"resume_with_cluster" mapstructure:"resume_with_cluster"`
-	Tags               []*Kv  `json:"tags" mapstructure:"tags"`
+	ClusterId          string   `json:"cluster_id" mapstructure:"cluster_id"`
+	Name               string   `json:"name" mapstructure:"name"`
+	Description        string   `json:"description" mapstructure:"description"`
+	VmCate             string   `json:"vm_cate" mapstructure:"vm_cate"`
+	VmNum              int32    `json:"vm_num" mapstructure:"vm_num"`
+	VolumeSizeGB       int64    `json:"volume_size_gb" mapstructure:"volume_size_gb"`
+	VolumeNum          int32    `json:"volume_num" mapstructure:"volume_num"`
+	DistributionPolicy string   `json:"distribution_policy" mapstructure:"distribution_policy"`
+	SpecifyAZ          string   `json:"specify_az" mapstructure:"specify_az"`
+	SpecifiedAZs       []string `json:"specified_azs" mapstructure:"specified_azs"`
+	Iops               int64    `json:"iops" mapstructure:"iops"`
+	Throughput         int64    `json:"throughput" mapstructure:"throughput"`
+	ResumeWithCluster  bool     `json:"resume_with_cluster" mapstructure:"resume_with_cluster"`
+	Tags               []*Kv    `json:"tags" mapstructure:"tags"`
 }
 
 type CreateWarehouseResp struct {
@@ -765,13 +771,15 @@ type DeleteWarehouseAutoScalingConfigReq struct {
 }
 
 type ChangeWarehouseDistributionReq struct {
-	WarehouseID        string `json:"warehouse_id" mapstructure:"warehouse_id"`
-	DistributionPolicy string `json:"distribution_policy" mapstructure:"distribution_policy"`
-	SpecifyAz          string `json:"specify_az" mapstructure:"specify_az"`
+	WarehouseID        string   `json:"warehouse_id" mapstructure:"warehouse_id"`
+	DistributionPolicy string   `json:"distribution_policy" mapstructure:"distribution_policy"`
+	SpecifyAz          string   `json:"specify_az" mapstructure:"specify_az"`
+	SpecifiedAZs       []string `json:"specified_azs" mapstructure:"specified_azs"`
+	ComputeNodeCount   uint32   `json:"compute_node_count" mapstructure:"compute_node_count"`
 }
 
 type ChangeWarehouseDistributionResp struct {
-	InfraActionId string `json:"infra_action_id" mapstructure:"infra_action_id"`
+	ActionID string `json:"action_id" mapstructure:"action_id"`
 }
 
 type GetVmInfoReq struct {

--- a/celerdatabyoc/resource_elastic_cluster_v2.go
+++ b/celerdatabyoc/resource_elastic_cluster_v2.go
@@ -164,7 +164,7 @@ func resourceElasticClusterV2() *schema.Resource {
 						"cngroup_size": {
 							Type:        schema.TypeInt,
 							Computed:    true,
-							Description: "Per-cngroup VM count as reported by the backend. Read-only.",
+							Description: "Per-cngroup VM count, derived as compute_node_count / cngroup_count. Read-only.",
 						},
 						"cngroup_count": {
 							Type:        schema.TypeInt,
@@ -297,7 +297,7 @@ func resourceElasticClusterV2() *schema.Resource {
 						"cngroup_size": {
 							Type:        schema.TypeInt,
 							Computed:    true,
-							Description: "Per-cngroup VM count as reported by the backend. Read-only.",
+							Description: "Per-cngroup VM count, derived as compute_node_count / cngroup_count. Read-only.",
 						},
 						"cngroup_count": {
 							Type:        schema.TypeInt,
@@ -1066,8 +1066,43 @@ func customizeEl2Diff(ctx context.Context, d *schema.ResourceDiff, m interface{}
 		return err
 	}
 
+	// Mark cngroup_count/cngroup_size Unknown when their inputs change so
+	// plan does not lock the old values; Update's final Read fills the new
+	// truth from backend post-apply.
+	markWarehouseCngroupUnknown(d)
+
 	err2 := SchedulingPolicyParamCheck(d)
 	return err2
+}
+
+func markWarehouseCngroupUnknown(d *schema.ResourceDiff) {
+	cngroupTriggers := []string{"distribution_policy", "specified_azs", "compute_node_count"}
+
+	if d.HasChange("default_warehouse") {
+		for _, f := range cngroupTriggers {
+			if d.HasChange("default_warehouse.0." + f) {
+				_ = d.SetNewComputed("default_warehouse.0.cngroup_count")
+				_ = d.SetNewComputed("default_warehouse.0.cngroup_size")
+				break
+			}
+		}
+	}
+
+	if d.HasChange("warehouse") {
+		whs, ok := d.Get("warehouse").([]interface{})
+		if !ok {
+			return
+		}
+		for i := range whs {
+			for _, f := range cngroupTriggers {
+				if d.HasChange(fmt.Sprintf("warehouse.%d.%s", i, f)) {
+					_ = d.SetNewComputed(fmt.Sprintf("warehouse.%d.cngroup_count", i))
+					_ = d.SetNewComputed(fmt.Sprintf("warehouse.%d.cngroup_size", i))
+					break
+				}
+			}
+		}
+	}
 }
 
 func resourceElasticClusterV2Create(ctx context.Context, d *schema.ResourceData, m interface{}) (diags diag.Diagnostics) {
@@ -1593,7 +1628,13 @@ func resourceElasticClusterV2Read(ctx context.Context, d *schema.ResourceData, m
 		whMap["name"] = warehouseName
 		whMap["compute_node_size"] = v.Module.InstanceType
 		whMap["compute_node_count"] = v.Module.Num
-		whMap["cngroup_size"] = int(v.CngroupSize)
+		// Backend reports cngroup_count but not cngroup_size; derive size locally
+		// to keep the field truthful (size = total nodes / cngroup count).
+		cngroupSize := 0
+		if v.CngroupCount > 0 {
+			cngroupSize = int(v.Module.Num) / int(v.CngroupCount)
+		}
+		whMap["cngroup_size"] = cngroupSize
 		whMap["cngroup_count"] = int(v.CngroupCount)
 		whMap["resource_tags"] = whTags
 		whMap["specified_azs"] = []string{}
@@ -2082,7 +2123,10 @@ func resourceElasticClusterV2Update(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
-	return diags
+	// Refresh state so Computed fields (cngroup_count, cngroup_size) reflect
+	// post-update backend reality. Without this, plan-time SetNewComputed marks
+	// these Unknown but apply leaves them unset.
+	return append(diags, resourceElasticClusterV2Read(ctx, d, m)...)
 }
 
 func upgradeAMI(ctx context.Context, clusterAPI cluster.IClusterAPI, req *cluster.UpgradeAMIReq) error {

--- a/celerdatabyoc/resource_elastic_cluster_v2.go
+++ b/celerdatabyoc/resource_elastic_cluster_v2.go
@@ -705,6 +705,19 @@ func customizeEl2Diff(ctx context.Context, d *schema.ResourceDiff, m interface{}
 		}
 	}
 
+	oldDwRaw, _ := d.GetChange("default_warehouse")
+	oldDwList := oldDwRaw.([]interface{})
+	var oldDefaultPolicy string
+	if len(oldDwList) > 0 {
+		oldDefaultPolicy = oldDwList[0].(map[string]interface{})["distribution_policy"].(string)
+	}
+	oldWhRaw, _ := d.GetChange("warehouse")
+	oldWhPolicyByName := make(map[string]string)
+	for _, ow := range oldWhRaw.([]interface{}) {
+		owMap := ow.(map[string]interface{})
+		oldWhPolicyByName[owMap["name"].(string)] = owMap["distribution_policy"].(string)
+	}
+
 	rawConfig := d.GetRawConfig()
 	for i, v := range warehouses {
 		vMap := v.(map[string]interface{})
@@ -716,6 +729,29 @@ func customizeEl2Diff(ctx context.Context, d *schema.ResourceDiff, m interface{}
 			rawWh = rawConfig.GetAttr("warehouse").Index(cty.NumberIntVal(int64(i - 1)))
 		}
 		userSetComputeNodeCount := !rawWh.GetAttr("compute_node_count").IsNull()
+
+		if policy == CROSSING_AZ {
+			var oldPolicy string
+			existedBefore := false
+			whLabel := "default_warehouse"
+			if i == 0 {
+				if !isNewResource && len(oldDwList) > 0 {
+					existedBefore = true
+					oldPolicy = oldDefaultPolicy
+				}
+			} else {
+				whName := vMap["name"].(string)
+				whLabel = fmt.Sprintf("warehouse %q", whName)
+				oldPolicy, existedBefore = oldWhPolicyByName[whName]
+			}
+			if !existedBefore {
+				return fmt.Errorf("distribution_policy %q is no longer supported for new warehouses; use %q or %q instead (%s)", CROSSING_AZ, SPECIFY_AZ, MULTI_AZ, whLabel)
+			}
+			if oldPolicy != CROSSING_AZ {
+				return fmt.Errorf("changing distribution_policy to %q is no longer supported; existing %q warehouses remain unchanged but cannot be recreated with this policy (%s)", CROSSING_AZ, CROSSING_AZ, whLabel)
+			}
+		}
+
 		if policy == MULTI_AZ {
 			if len(vMap["specify_az"].(string)) > 0 {
 				return errors.New("specify_az must be empty when distribution_policy is \"multi_az\"")
@@ -2289,7 +2325,7 @@ func updateWarehouse(ctx context.Context, req *UpdateWarehouseReq, multiAz bool)
 		stateResp, err := WaitClusterStateChangeComplete(ctx, &waitStateReq{
 			clusterAPI: clusterAPI,
 			clusterID:  clusterId,
-			actionID:   resp.ActionID,
+			actionID:   resp.InfraActionId,
 			timeout:    common.DeployOrScaleClusterTimeout,
 			pendingStates: []string{
 				string(cluster.ClusterStateDeploying),
@@ -2306,11 +2342,11 @@ func updateWarehouse(ctx context.Context, req *UpdateWarehouseReq, multiAz bool)
 		})
 
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("failed to wait change warehouse distribution[%s], clusterId:%s warehouseId:%s, errMsg:%s", resp.ActionID, clusterId, warehouseId, err.Error()))
+			return diag.FromErr(fmt.Errorf("failed to wait change warehouse distribution[%s], clusterId:%s warehouseId:%s, errMsg:%s", resp.InfraActionId, clusterId, warehouseId, err.Error()))
 		}
 
 		if stateResp.ClusterState == string(cluster.ClusterStateAbnormal) {
-			return diag.FromErr(fmt.Errorf("failed to wait change warehouse distribution[%s], clusterId:%s warehouseId:%s, errMsg:%s", resp.ActionID, clusterId, warehouseId, stateResp.AbnormalReason))
+			return diag.FromErr(fmt.Errorf("failed to wait change warehouse distribution[%s], clusterId:%s warehouseId:%s, errMsg:%s", resp.InfraActionId, clusterId, warehouseId, stateResp.AbnormalReason))
 		}
 	}
 

--- a/celerdatabyoc/resource_elastic_cluster_v2.go
+++ b/celerdatabyoc/resource_elastic_cluster_v2.go
@@ -161,6 +161,16 @@ func resourceElasticClusterV2() *schema.Resource {
 							MaxItems: 2,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						"cngroup_size": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Per-cngroup VM count as reported by the backend. Read-only.",
+						},
+						"cngroup_count": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Current cngroup count as reported by the backend. Read-only. Scale-in cannot bring compute_node_count below this value.",
+						},
 						"resource_tags": {
 							Type:        schema.TypeMap,
 							Optional:    true,
@@ -283,6 +293,16 @@ func resourceElasticClusterV2() *schema.Resource {
 							Optional: true,
 							MaxItems: 2,
 							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"cngroup_size": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Per-cngroup VM count as reported by the backend. Read-only.",
+						},
+						"cngroup_count": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Current cngroup count as reported by the backend. Read-only. Scale-in cannot bring compute_node_count below this value.",
 						},
 						"resource_tags": {
 							Type:        schema.TypeMap,
@@ -707,15 +727,15 @@ func customizeEl2Diff(ctx context.Context, d *schema.ResourceDiff, m interface{}
 
 	oldDwRaw, _ := d.GetChange("default_warehouse")
 	oldDwList := oldDwRaw.([]interface{})
-	var oldDefaultPolicy string
+	var oldDefaultMap map[string]interface{}
 	if len(oldDwList) > 0 {
-		oldDefaultPolicy = oldDwList[0].(map[string]interface{})["distribution_policy"].(string)
+		oldDefaultMap, _ = oldDwList[0].(map[string]interface{})
 	}
 	oldWhRaw, _ := d.GetChange("warehouse")
-	oldWhPolicyByName := make(map[string]string)
+	oldWhByName := make(map[string]map[string]interface{})
 	for _, ow := range oldWhRaw.([]interface{}) {
 		owMap := ow.(map[string]interface{})
-		oldWhPolicyByName[owMap["name"].(string)] = owMap["distribution_policy"].(string)
+		oldWhByName[owMap["name"].(string)] = owMap
 	}
 
 	rawConfig := d.GetRawConfig()
@@ -730,21 +750,28 @@ func customizeEl2Diff(ctx context.Context, d *schema.ResourceDiff, m interface{}
 		}
 		userSetComputeNodeCount := !rawWh.GetAttr("compute_node_count").IsNull()
 
-		if policy == CROSSING_AZ {
-			var oldPolicy string
-			existedBefore := false
-			whLabel := "default_warehouse"
-			if i == 0 {
-				if !isNewResource && len(oldDwList) > 0 {
-					existedBefore = true
-					oldPolicy = oldDefaultPolicy
-				}
-			} else {
-				whName := vMap["name"].(string)
-				whLabel = fmt.Sprintf("warehouse %q", whName)
-				oldPolicy, existedBefore = oldWhPolicyByName[whName]
+		var oldWhMap map[string]interface{}
+		whLabel := "default_warehouse"
+		if i == 0 {
+			if !isNewResource {
+				oldWhMap = oldDefaultMap
 			}
-			if !existedBefore {
+		} else {
+			whName := vMap["name"].(string)
+			whLabel = fmt.Sprintf("warehouse %q", whName)
+			oldWhMap = oldWhByName[whName]
+		}
+		var oldPolicy string
+		var oldCount, oldCngroupCount, oldCngroupSize int
+		if oldWhMap != nil {
+			oldPolicy, _ = oldWhMap["distribution_policy"].(string)
+			oldCount, _ = oldWhMap["compute_node_count"].(int)
+			oldCngroupCount, _ = oldWhMap["cngroup_count"].(int)
+			oldCngroupSize, _ = oldWhMap["cngroup_size"].(int)
+		}
+
+		if policy == CROSSING_AZ {
+			if oldWhMap == nil {
 				return fmt.Errorf("distribution_policy %q is no longer supported for new warehouses; use %q or %q instead (%s)", CROSSING_AZ, SPECIFY_AZ, MULTI_AZ, whLabel)
 			}
 			if oldPolicy != CROSSING_AZ {
@@ -765,6 +792,13 @@ func customizeEl2Diff(ctx context.Context, d *schema.ResourceDiff, m interface{}
 			if cnc <= 0 || cnc%len(azs) != 0 {
 				return fmt.Errorf("compute_node_count (%d) must be a positive multiple of len(specified_azs) (%d) when distribution_policy is \"multi_az\"", cnc, len(azs))
 			}
+			// Preserves source group-scaling partitions on the target per-AZ layout.
+			if oldPolicy == SPECIFY_AZ && oldCount > 0 {
+				expected := oldCount * len(azs)
+				if cnc != expected {
+					return fmt.Errorf("switching %s from specify_az to multi_az requires compute_node_count to be %d (current %d multiplied by %d AZs)", whLabel, expected, oldCount, len(azs))
+				}
+			}
 		} else {
 			if policy != SPECIFY_AZ && len(vMap["specify_az"].(string)) > 0 {
 				return errors.New("specify_az parameter only takes effect when the distribution_policy value is \"specify_az\"")
@@ -772,6 +806,17 @@ func customizeEl2Diff(ctx context.Context, d *schema.ResourceDiff, m interface{}
 			if len(azs) > 0 {
 				return errors.New("specified_azs parameter only takes effect when the distribution_policy value is \"multi_az\"")
 			}
+		}
+
+		// Same-policy scaling keeps cngroup partitions evenly sized.
+		if oldCngroupCount > 0 && oldPolicy == policy && cnc != oldCount && cnc%oldCngroupCount != 0 {
+			return fmt.Errorf("%s compute_node_count %d must be a multiple of current cngroup_count %d", whLabel, cnc, oldCngroupCount)
+		}
+
+		// multi_az → specify_az: backend chunks new VMs with the source
+		// cngroup_size, so compute_node_count must divide cleanly.
+		if oldPolicy == MULTI_AZ && policy == SPECIFY_AZ && oldCngroupSize > 0 && cnc%oldCngroupSize != 0 {
+			return fmt.Errorf("%s switching from multi_az to specify_az requires compute_node_count %d to be a multiple of current cngroup_size %d", whLabel, cnc, oldCngroupSize)
 		}
 	}
 
@@ -1548,6 +1593,8 @@ func resourceElasticClusterV2Read(ctx context.Context, d *schema.ResourceData, m
 		whMap["name"] = warehouseName
 		whMap["compute_node_size"] = v.Module.InstanceType
 		whMap["compute_node_count"] = v.Module.Num
+		whMap["cngroup_size"] = int(v.CngroupSize)
+		whMap["cngroup_count"] = int(v.CngroupCount)
 		whMap["resource_tags"] = whTags
 		whMap["specified_azs"] = []string{}
 		if !netResp.Network.MultiAz {

--- a/celerdatabyoc/resource_elastic_cluster_v2.go
+++ b/celerdatabyoc/resource_elastic_cluster_v2.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -19,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/go-cty/cty"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -27,6 +29,7 @@ const (
 	DEFAULT_WAREHOUSE_NAME = "default_warehouse"
 	CROSSING_AZ            = "crossing_az"
 	SPECIFY_AZ             = "specify_az"
+	MULTI_AZ               = "multi_az"
 )
 
 // V2 support multi-warehouse
@@ -137,6 +140,7 @@ func resourceElasticClusterV2() *schema.Resource {
 							Optional:     true,
 							Default:      3,
 							ValidateFunc: validation.IntAtLeast(1),
+							Description:  "Total compute node count. When distribution_policy is \"multi_az\", must be a positive multiple of len(specified_azs).",
 						},
 						"distribution_policy": {
 							Type:     schema.TypeString,
@@ -144,11 +148,18 @@ func resourceElasticClusterV2() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{
 								SPECIFY_AZ,
 								CROSSING_AZ,
+								MULTI_AZ,
 							}, false),
 						},
 						"specify_az": {
 							Type:     schema.TypeString,
 							Optional: true,
+						},
+						"specified_azs": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 2,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"resource_tags": {
 							Type:        schema.TypeMap,
@@ -252,6 +263,7 @@ func resourceElasticClusterV2() *schema.Resource {
 							Optional:     true,
 							Default:      3,
 							ValidateFunc: validation.IntAtLeast(1),
+							Description:  "Total compute node count. When distribution_policy is \"multi_az\", must be a positive multiple of len(specified_azs).",
 						},
 						"distribution_policy": {
 							Type:     schema.TypeString,
@@ -259,11 +271,18 @@ func resourceElasticClusterV2() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{
 								SPECIFY_AZ,
 								CROSSING_AZ,
+								MULTI_AZ,
 							}, false),
 						},
 						"specify_az": {
 							Type:     schema.TypeString,
 							Optional: true,
+						},
+						"specified_azs": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 2,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"resource_tags": {
 							Type:        schema.TypeMap,
@@ -686,10 +705,37 @@ func customizeEl2Diff(ctx context.Context, d *schema.ResourceDiff, m interface{}
 		}
 	}
 
-	for _, v := range warehouses {
+	rawConfig := d.GetRawConfig()
+	for i, v := range warehouses {
 		vMap := v.(map[string]interface{})
-		if vMap["distribution_policy"].(string) != SPECIFY_AZ && len(vMap["specify_az"].(string)) > 0 {
-			return errors.New("specify_az parameter only takes effect when the distribution_policy value is \"specify_az\"")
+		policy := vMap["distribution_policy"].(string)
+		azs := toStringSlice(vMap["specified_azs"])
+		cnc := vMap["compute_node_count"].(int)
+		rawWh := rawConfig.GetAttr("default_warehouse").Index(cty.NumberIntVal(0))
+		if i > 0 {
+			rawWh = rawConfig.GetAttr("warehouse").Index(cty.NumberIntVal(int64(i - 1)))
+		}
+		userSetComputeNodeCount := !rawWh.GetAttr("compute_node_count").IsNull()
+		if policy == MULTI_AZ {
+			if len(vMap["specify_az"].(string)) > 0 {
+				return errors.New("specify_az must be empty when distribution_policy is \"multi_az\"")
+			}
+			if len(azs) != 2 {
+				return errors.New("in multi_az distribution policy, specified_azs must contain exactly 2 AZs")
+			}
+			if !userSetComputeNodeCount {
+				return errors.New("compute_node_count is required when distribution_policy is \"multi_az\"")
+			}
+			if cnc <= 0 || cnc%len(azs) != 0 {
+				return fmt.Errorf("compute_node_count (%d) must be a positive multiple of len(specified_azs) (%d) when distribution_policy is \"multi_az\"", cnc, len(azs))
+			}
+		} else {
+			if policy != SPECIFY_AZ && len(vMap["specify_az"].(string)) > 0 {
+				return errors.New("specify_az parameter only takes effect when the distribution_policy value is \"specify_az\"")
+			}
+			if len(azs) > 0 {
+				return errors.New("specified_azs parameter only takes effect when the distribution_policy value is \"multi_az\"")
+			}
 		}
 	}
 
@@ -1061,6 +1107,7 @@ func resourceElasticClusterV2Create(ctx context.Context, d *schema.ResourceData,
 		InstanceType:       defaultWhMap["compute_node_size"].(string),
 		DistributionPolicy: defaultWhMap["distribution_policy"].(string),
 		SpecifyAZ:          defaultWhMap["specify_az"].(string),
+		SpecifiedAZs:       toStringSlice(defaultWhMap["specified_azs"]),
 		Tags:               defaultWHTags,
 		DiskInfo: &cluster.DiskInfo{
 			Number:  2,
@@ -1466,10 +1513,14 @@ func resourceElasticClusterV2Read(ctx context.Context, d *schema.ResourceData, m
 		whMap["compute_node_size"] = v.Module.InstanceType
 		whMap["compute_node_count"] = v.Module.Num
 		whMap["resource_tags"] = whTags
+		whMap["specified_azs"] = []string{}
 		if !netResp.Network.MultiAz {
 			whMap["distribution_policy"] = ""
 		} else {
 			whMap["distribution_policy"] = v.DistributionPolicyStr
+			if v.DistributionPolicyStr == MULTI_AZ {
+				whMap["specified_azs"] = v.SpecifiedAZs
+			}
 		}
 		whMap["specify_az"] = v.SpecifyAZ
 
@@ -2045,6 +2096,7 @@ func createWarehouse(ctx context.Context, clusterAPI cluster.IClusterAPI, cluste
 		Throughput:         int64(throughput),
 		DistributionPolicy: whParamMap["distribution_policy"].(string),
 		SpecifyAZ:          whParamMap["specify_az"].(string),
+		SpecifiedAZs:       toStringSlice(whParamMap["specified_azs"]),
 		Tags:               whTags,
 	}
 
@@ -2214,42 +2266,51 @@ func updateWarehouse(ctx context.Context, req *UpdateWarehouseReq, multiAz bool)
 
 	warehouseName := newParamMap["name"].(string)
 
+	oldSpecifiedAZs := toStringSlice(oldParamMap["specified_azs"])
+	newSpecifiedAZs := toStringSlice(newParamMap["specified_azs"])
 	computeNodeDistributionChanged := oldParamMap["distribution_policy"].(string) != newParamMap["distribution_policy"].(string) ||
-		(newParamMap["distribution_policy"].(string) == string(cluster.DistributionPolicySpecifyAZ) && oldParamMap["specify_az"].(string) != newParamMap["specify_az"].(string))
+		(newParamMap["distribution_policy"].(string) == string(cluster.DistributionPolicySpecifyAZ) && oldParamMap["specify_az"].(string) != newParamMap["specify_az"].(string)) ||
+		(newParamMap["distribution_policy"].(string) == string(cluster.DistributionPolicyMultiAZ) && !reflect.DeepEqual(oldSpecifiedAZs, newSpecifiedAZs))
 	if computeNodeDistributionChanged && multiAz {
 		distributionPolicy := newParamMap["distribution_policy"].(string)
 		specifyAz := newParamMap["specify_az"].(string)
+		computeNodeCount := uint32(newParamMap["compute_node_count"].(int))
 		resp, err := clusterAPI.ChangeWarehouseDistribution(ctx, &cluster.ChangeWarehouseDistributionReq{
 			WarehouseID:        warehouseId,
 			DistributionPolicy: distributionPolicy,
 			SpecifyAz:          specifyAz,
+			SpecifiedAZs:       newSpecifiedAZs,
+			ComputeNodeCount:   computeNodeCount,
 		})
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("failed to change warehouse distribution, clusterId:%s warehouseId:%s, errMsg:%s", clusterId, warehouseId, err.Error()))
 		}
 
-		infraActionResp, err := WaitClusterInfraActionStateChangeComplete(ctx, &waitStateReq{
+		stateResp, err := WaitClusterStateChangeComplete(ctx, &waitStateReq{
 			clusterAPI: clusterAPI,
 			clusterID:  clusterId,
-			actionID:   resp.InfraActionId,
+			actionID:   resp.ActionID,
 			timeout:    common.DeployOrScaleClusterTimeout,
 			pendingStates: []string{
-				string(cluster.ClusterInfraActionStatePending),
-				string(cluster.ClusterInfraActionStateOngoing),
+				string(cluster.ClusterStateDeploying),
+				string(cluster.ClusterStateScaling),
+				string(cluster.ClusterStateResuming),
+				string(cluster.ClusterStateSuspending),
+				string(cluster.ClusterStateReleasing),
+				string(cluster.ClusterStateUpdating),
 			},
 			targetStates: []string{
-				string(cluster.ClusterInfraActionStateSucceeded),
-				string(cluster.ClusterInfraActionStateCompleted),
-				string(cluster.ClusterInfraActionStateFailed),
+				string(cluster.ClusterStateRunning),
+				string(cluster.ClusterStateAbnormal),
 			},
 		})
 
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("failed to wait change warehouse distribution[%s], clusterId:%s warehouseId:%s, errMsg:%s", resp.InfraActionId, clusterId, warehouseId, err.Error()))
+			return diag.FromErr(fmt.Errorf("failed to wait change warehouse distribution[%s], clusterId:%s warehouseId:%s, errMsg:%s", resp.ActionID, clusterId, warehouseId, err.Error()))
 		}
 
-		if infraActionResp.InfraActionState == string(cluster.ClusterInfraActionStateFailed) {
-			return diag.FromErr(fmt.Errorf("failed to wait change warehouse distribution[%s], clusterId:%s warehouseId:%s, errMsg:%s", resp.InfraActionId, clusterId, warehouseId, infraActionResp.ErrMsg))
+		if stateResp.ClusterState == string(cluster.ClusterStateAbnormal) {
+			return diag.FromErr(fmt.Errorf("failed to wait change warehouse distribution[%s], clusterId:%s warehouseId:%s, errMsg:%s", resp.ActionID, clusterId, warehouseId, stateResp.AbnormalReason))
 		}
 	}
 
@@ -3139,6 +3200,14 @@ func handleScaleWarehouses(ctx context.Context, d *schema.ResourceData, clusterA
 			if !ok {
 				continue
 			}
+			// Cross-policy transitions route through ChangeWarehouseDistribution,
+			// which already applies the caller's node count verbatim at the
+			// backend. Issuing a separate ScaleWarehouseNum here would collide
+			// with the already-scaled warehouse (errMsg: "vm_num of nodes
+			// cannot be the same as the current number").
+			if oldWh["distribution_policy"].(string) != newWh["distribution_policy"].(string) {
+				continue
+			}
 			whExternalInfoStr := whExternalInfoMap[whName].(string)
 			whExternalInfo := &cluster.WarehouseExternalInfo{}
 			json.Unmarshal([]byte(whExternalInfoStr), whExternalInfo)
@@ -3156,6 +3225,10 @@ func handleScaleWarehouses(ctx context.Context, d *schema.ResourceData, clusterA
 		defaultOld, defaultNew := d.GetChange("default_warehouse")
 		defaultOldWh := defaultOld.([]interface{})[0].(map[string]interface{})
 		defaultNewWh := defaultNew.([]interface{})[0].(map[string]interface{})
+
+		if defaultOldWh["distribution_policy"].(string) != defaultNewWh["distribution_policy"].(string) {
+			return nil
+		}
 
 		defaultWhExternalInfoStr := whExternalInfoMap[DEFAULT_WAREHOUSE_NAME].(string)
 		defaultWhExternalInfo := &cluster.WarehouseExternalInfo{}
@@ -3447,6 +3520,23 @@ func handleWarehouseScaleUpAndUpgradeAMI(ctx context.Context, d *schema.Resource
 	}
 
 	return nil
+}
+
+func toStringSlice(v interface{}) []string {
+	if v == nil {
+		return nil
+	}
+	raw, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, item := range raw {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 func configArrowFlight(ctx context.Context, clusterAPI cluster.IClusterAPI, req *cluster.SetClusterArrowFlightReq) diag.Diagnostics {

--- a/docs/resources/elastic_cluster_v2.md
+++ b/docs/resources/elastic_cluster_v2.md
@@ -68,7 +68,7 @@ resource "celerdatabyoc_elastic_cluster_v2" "elastic_cluster_1" {
     // When using an EBS-backed instance type, specify the following two parameters. Otherwise, delete them.
     compute_node_ebs_disk_number   = <compute_node_ebs_disk_number>
     compute_node_ebs_disk_per_size = <compute_node_ebs_disk_per_size>
-    distribution_policy            = "{specify_az | crossing_az | multi_az}"
+    distribution_policy            = "{specify_az | multi_az}"
     
     // specify_az                  = "us-west-2b"
     // specified_azs               = ["us-west-2a", "us-west-2b"]
@@ -189,8 +189,8 @@ The `celerdatabyoc_elastic_cluster_v2` resource contains the following required 
     - `auto_scaling_policy`: (Optional) This policy will automatically scale the number of compute nodes, based on CPU utilization of the warehouse. For more information, see [Enable Auto Scaling for your warehouse](https://docs.celerdata.com/BYOC/docs/cluster_management/scale_cluster#compute-autoscaling). You can generate the `policy_json` value for this argument using the [`celerdatabyoc_auto_scaling_policy`](../resources/warehouse_auto_scaling_policy.md) resource.
     - `distribution_policy`: (Optional, available only for AWS) The compute node distribution policy for the warehouse if you want to enable Multi-AZ deployment for the cluster. Valid values:
         - `specify_az`: Nodes are deployed in the primary availability zone.
-        - `crossing_az`: Nodes are deployed across the three availability zones of the network configuration.
         - `multi_az`: Nodes are distributed evenly across the two availability zones specified in `specified_azs`. `compute_node_count` is required and must be a positive multiple of `len(specified_azs)`.
+        - `crossing_az`: **Deprecated.** Cannot be used when creating a new warehouse or changing the `distribution_policy` of an existing warehouse; `terraform plan` will reject it. Warehouses already provisioned with `crossing_az` continue to work unchanged; migrate them to `multi_az` or `specify_az` when convenient.
 
       For more information, see [Multi-AZ Deployment](https://docs.celerdata.com/BYOC/docs/get_started/create_cluster/aws_cluster/multi-az/).
 
@@ -247,8 +247,8 @@ The `celerdatabyoc_elastic_cluster_v2` resource contains the following required 
 
     - `distribution_policy`: (Available only for AWS) The Compute Node distribution policy for the warehouse if you want to enable Multi-AZ deployment for the cluster. Valid values:
         - `specify_az`: Nodes are deployed in the primary availability zone.
-        - `crossing_az`: Nodes are deployed across the three availability zones of the network configuration.
         - `multi_az`: Nodes are distributed evenly across the two availability zones specified in `specified_azs`. `compute_node_count` is required and must be a positive multiple of `len(specified_azs)`. When changing the warehouse size under this policy, `compute_node_count` is forwarded to the backend in a single distribution change, so no subsequent scale operation is issued.
+        - `crossing_az`: **Deprecated.** Cannot be used when creating a new warehouse or changing the `distribution_policy` of an existing warehouse; `terraform plan` will reject it. Warehouses already provisioned with `crossing_az` continue to work unchanged; migrate them to `multi_az` or `specify_az` when convenient.
 
       For more information, see [Multi-AZ Deployment](https://docs.celerdata.com/BYOC/docs/get_started/create_cluster/aws_cluster/multi-az/).
 

--- a/docs/resources/elastic_cluster_v2.md
+++ b/docs/resources/elastic_cluster_v2.md
@@ -68,9 +68,10 @@ resource "celerdatabyoc_elastic_cluster_v2" "elastic_cluster_1" {
     // When using an EBS-backed instance type, specify the following two parameters. Otherwise, delete them.
     compute_node_ebs_disk_number   = <compute_node_ebs_disk_number>
     compute_node_ebs_disk_per_size = <compute_node_ebs_disk_per_size>
-    distribution_policy            = "{specify_az | crossing_az}"
+    distribution_policy            = "{specify_az | crossing_az | multi_az}"
     
     // specify_az                  = "us-west-2b"
+    // specified_azs               = ["us-west-2a", "us-west-2b"]
     // expected_state="Suspended"
     // auto_scaling_policy         = celerdatabyoc_auto_scaling_policy.policy_1.policy_json
     
@@ -186,11 +187,18 @@ The `celerdatabyoc_elastic_cluster_v2` resource contains the following required 
     - `resource_tags`: The tags to be attached to the warehouse (Please note that resource_tags is a concept in ClelerData. For AWS and Azure, it will be added as a tag to the corresponding resources. For GCP Cloud, it will be added as a label to the corresponding GCP resources).
 
     - `auto_scaling_policy`: (Optional) This policy will automatically scale the number of compute nodes, based on CPU utilization of the warehouse. For more information, see [Enable Auto Scaling for your warehouse](https://docs.celerdata.com/BYOC/docs/cluster_management/scale_cluster#compute-autoscaling). You can generate the `policy_json` value for this argument using the [`celerdatabyoc_auto_scaling_policy`](../resources/warehouse_auto_scaling_policy.md) resource.
-    - `distribution_policy`: (Optional, available only for AWS) The compute node distribution policy for the warehouse if you want to enable Multi-AZ deployment for the cluster. Valid values: `specify_az` (Nodes are deployed in the primary availability zone) and `crossing_az` (Nodes are deployed across the three availability zone). For more information, see [Multi-AZ Deployment](https://docs.celerdata.com/BYOC/docs/get_started/create_cluster/aws_cluster/multi-az/).
+    - `distribution_policy`: (Optional, available only for AWS) The compute node distribution policy for the warehouse if you want to enable Multi-AZ deployment for the cluster. Valid values:
+        - `specify_az`: Nodes are deployed in the primary availability zone.
+        - `crossing_az`: Nodes are deployed across the three availability zones of the network configuration.
+        - `multi_az`: Nodes are distributed evenly across the two availability zones specified in `specified_azs`. `compute_node_count` is required and must be a positive multiple of `len(specified_azs)`.
+
+      For more information, see [Multi-AZ Deployment](https://docs.celerdata.com/BYOC/docs/get_started/create_cluster/aws_cluster/multi-az/).
 
       ~> To enable Multi-AZ Deployment, you must deploy at least 3 coordinator nodes, that is, `coordinator_node_count` must be greater or equal to `3`.
 
     - `specify_az`: (Optional, available only for AWS) The primary availability zone for node deployment. This argument is available only when `distribution_policy` is set to `specify_az`.
+
+    - `specified_azs`: (Optional, available only for AWS) The list of availability zones across which compute nodes are evenly distributed. This argument is available only when `distribution_policy` is set to `multi_az`, and must contain exactly 2 AZs. `compute_node_count` must be a positive multiple of the length of this list.
 
 - `custom_ami`: (Optional, available only for AWS) The Amazon Machine Image (AMI) used to deploy the cluster. You can use custom AMI for deployment. You can only specify this parameter when creating the cluster. If this argument is not specified, the default AMI is used.
   - `ami`: The ID of the custom AMI.
@@ -237,11 +245,18 @@ The `celerdatabyoc_elastic_cluster_v2` resource contains the following required 
 
     - `auto_scaling_policy`: This policy will automatically scale the number of Compute nodes (CN), based on CPU utilization of the warehouse. For more information, see [Enable Auto Scaling for your warehouse](https://docs.celerdata.com/BYOC/docs/cluster_management/scale_cluster#auto-scaling). You can generate the `policy_json` value for this argument using the [`celerdatabyoc_auto_scaling_policy`](../resources/warehouse_auto_scaling_policy.md) resource.
 
-    - `distribution_policy`: (Available only for AWS) The Compute Node distribution policy for the warehouse if you want to enable Multi-AZ deployment for the cluster. Valid values: `specify_az` (Nodes are deployed in the primary availability zone) and `crossing_az` (Nodes are deployed across the three availability zone). For more information, see [Multi-AZ Deployment](https://docs.celerdata.com/BYOC/docs/get_started/create_cluster/aws_cluster/multi-az/).
+    - `distribution_policy`: (Available only for AWS) The Compute Node distribution policy for the warehouse if you want to enable Multi-AZ deployment for the cluster. Valid values:
+        - `specify_az`: Nodes are deployed in the primary availability zone.
+        - `crossing_az`: Nodes are deployed across the three availability zones of the network configuration.
+        - `multi_az`: Nodes are distributed evenly across the two availability zones specified in `specified_azs`. `compute_node_count` is required and must be a positive multiple of `len(specified_azs)`. When changing the warehouse size under this policy, `compute_node_count` is forwarded to the backend in a single distribution change, so no subsequent scale operation is issued.
+
+      For more information, see [Multi-AZ Deployment](https://docs.celerdata.com/BYOC/docs/get_started/create_cluster/aws_cluster/multi-az/).
 
       ~> To enable Multi-AZ Deployment, you must deploy at least 3 Coordinator Nodes, that is, `coordinator_node_count` must be greater or equal to `3`.
 
     - `specify_az`:  (Available only for AWS) The primary availability zone for node deployment. This argument is available only when `distribution_policy` is set to `specify_az`.
+
+    - `specified_azs`: (Available only for AWS) The list of availability zones across which compute nodes are evenly distributed. This argument is available only when `distribution_policy` is set to `multi_az`, and must contain exactly 2 AZs. `compute_node_count` must be a positive multiple of the length of this list.
 - `global_session_variables`: Global session variables of the cluster. You can find all configurable variables by `select VARIABLE_NAME from information_schema.global_variables;`.
 - `ldap_ssl_certs`: (Available only for AWS) The path in the AWS S3 bucket that stores the LDAP SSL certificates. Multiple paths must be separated by commas (,). CelerData supports using LDAP over SSL by uploading the LDAP SSL certificates from S3. To allow CelerData to successfully fetch the certificates, you must grant the `ListObject` and `GetObject` permissions to CelerData. To delete the certificates uploaded, you only need to remove this argument.
 


### PR DESCRIPTION
## Summary

Add the `multi_az` distribution policy alongside `specify_az` and `crossing_az`:

- **Schema**: `default_warehouse` and `warehouse` now accept `distribution_policy = multi_az` with `specified_azs` (exactly 2 AZs) and `compute_node_count` constrained to a positive multiple of `len(specified_azs)`.
- **`warehouse_size` support** for multi_az warehouses; `compute_node_count` is forwarded to `ChangeWarehouseDistribution` and divisibility is validated at plan time.
- **Update path**: cross-policy transitions route through `ChangeWarehouseDistribution` with the caller's total node count, and the subsequent `ScaleWarehouseNum` is skipped so the already-scaled warehouse does not error with *"vm_num cannot be the same as the current number"*.

## Test plan

- [x] Full multi-AZ e2e suite on stage: **22/22 PASSED** (1h42m) with dev-override of this provider; every cross-policy conversion (including `multi_az → specify_az` with count change, which previously failed with the redundant scale-num) and AZ membership swap verified green.
- [ ] Backend side of the feature — see companion PR in celerdata-byoc-cloud.