### PR TITLE
feat(azure): support Private Link on azure_network resource

### DIFF
--- a/celerdata-sdk/service/network/entity.go
+++ b/celerdata-sdk/service/network/entity.go
@@ -20,6 +20,7 @@ type CreateAzureNetworkReq struct {
 	VirtualNetworkResourceId string `json:"virtual_network_resource_id" mapstructure:"virtual_network_resource_id"`
 	SubnetName               string `json:"subnet_name" mapstructure:"subnet_name"`
 	PublicAccess             bool   `json:"public_access" mapstructure:"public_access"`
+	VpcEndpointId            string `json:"vpc_endpoint_id" mapstructure:"vpc_endpoint_id"`
 }
 
 type CreateNetworkResp struct {

--- a/celerdatabyoc/resource_azure_network.go
+++ b/celerdatabyoc/resource_azure_network.go
@@ -58,6 +58,12 @@ func azureResourceNetwork() *schema.Resource {
 				ForceNew:    true,
 				Default:     false,
 			},
+			"vpc_endpoint_id": {
+				Type:        schema.TypeString,
+				Description: "Resource ID of the Azure Private Endpoint used to reach the cluster over Azure Private Link. When set, the cluster is accessed via Private Link instead of the public network. The Private Endpoint must be Approved and connected to the CelerData Private Link Service in the same VNet as the cluster's subnet.",
+				Optional:    true,
+				ForceNew:    true,
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -77,6 +83,7 @@ func azureResourceNetworkCreate(ctx context.Context, d *schema.ResourceData, m i
 		VirtualNetworkResourceId: d.Get("virtual_network_resource_id").(string),
 		SubnetName:               d.Get("subnet_name").(string),
 		PublicAccess:             d.Get("public_accessible").(bool),
+		VpcEndpointId:            d.Get("vpc_endpoint_id").(string),
 	}
 
 	resp, err := networkCli.CreateAzureNetwork(ctx, req)
@@ -102,7 +109,10 @@ func azureResourceNetworkRead(ctx context.Context, d *schema.ResourceData, m int
 	}
 	if resp.Network == nil || len(resp.Network.BizID) == 0 {
 		d.SetId("")
+		return diags
 	}
+
+	d.Set("vpc_endpoint_id", resp.Network.VpcEndpointId)
 
 	log.Printf("[DEBUG] get Network, resp:%+v", resp)
 	return diags

--- a/docs/resources/azure_network.md
+++ b/docs/resources/azure_network.md
@@ -58,6 +58,8 @@ This resource contains the following required arguments and optional arguments:
 
 - `public_accessible`: (Forces new resource) Whether the cluster can be accessed from public networks. Valid values: `true` and `false`. If you set this argument to `true`, CelerData will attach a load balancer to the cluster to distribute incoming queries, and will assign a public domain name to the cluster so you can access the cluster over a public network. If you set this argument to `false`, the cluster is accessible only through a private domain name.
 
+- `vpc_endpoint_id`: (Forces new resource) The resource ID of the Azure Private Endpoint used to access the cluster via Azure Private Link. When this argument is set, the cluster is reachable over Private Link instead of the public network. The referenced Private Endpoint must already be Approved against the CelerData Private Link Service and must reside in the same virtual network as the subnet specified by `subnet_name`. See [azurerm_private_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint).
+
 ## Attribute Reference
 
 This resource exports the following attributes:'


### PR DESCRIPTION
Add optional vpc_endpoint_id field on celerdatabyoc_azure_network for passing the Azure Private Endpoint Resource ID used by End-to-End Private Link deployments.