### PR TITLE
[Feature] Support 3-AZ multi_az distribution policy for warehouses

### DIFF
--- a/celerdatabyoc/resource_elastic_cluster_v2.go
+++ b/celerdatabyoc/resource_elastic_cluster_v2.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -156,10 +155,11 @@ func resourceElasticClusterV2() *schema.Resource {
 							Optional: true,
 						},
 						"specified_azs": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 2,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Type:             schema.TypeList,
+							Optional:         true,
+							MaxItems:         3,
+							Elem:             &schema.Schema{Type: schema.TypeString},
+							DiffSuppressFunc: suppressSpecifiedAZsDiff,
 						},
 						"cngroup_size": {
 							Type:        schema.TypeInt,
@@ -289,10 +289,11 @@ func resourceElasticClusterV2() *schema.Resource {
 							Optional: true,
 						},
 						"specified_azs": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 2,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Type:             schema.TypeList,
+							Optional:         true,
+							MaxItems:         3,
+							Elem:             &schema.Schema{Type: schema.TypeString},
+							DiffSuppressFunc: suppressSpecifiedAZsDiff,
 						},
 						"cngroup_size": {
 							Type:        schema.TypeInt,
@@ -763,11 +764,13 @@ func customizeEl2Diff(ctx context.Context, d *schema.ResourceDiff, m interface{}
 		}
 		var oldPolicy string
 		var oldCount, oldCngroupCount, oldCngroupSize int
+		var oldSpecifiedAZs []string
 		if oldWhMap != nil {
 			oldPolicy, _ = oldWhMap["distribution_policy"].(string)
 			oldCount, _ = oldWhMap["compute_node_count"].(int)
 			oldCngroupCount, _ = oldWhMap["cngroup_count"].(int)
 			oldCngroupSize, _ = oldWhMap["cngroup_size"].(int)
+			oldSpecifiedAZs = toStringSlice(oldWhMap["specified_azs"])
 		}
 
 		if policy == CROSSING_AZ {
@@ -783,8 +786,8 @@ func customizeEl2Diff(ctx context.Context, d *schema.ResourceDiff, m interface{}
 			if len(vMap["specify_az"].(string)) > 0 {
 				return errors.New("specify_az must be empty when distribution_policy is \"multi_az\"")
 			}
-			if len(azs) != 2 {
-				return errors.New("in multi_az distribution policy, specified_azs must contain exactly 2 AZs")
+			if len(azs) < 2 || len(azs) > 3 {
+				return errors.New("in multi_az distribution policy, specified_azs must contain 2 or 3 AZs")
 			}
 			if !userSetComputeNodeCount {
 				return errors.New("compute_node_count is required when distribution_policy is \"multi_az\"")
@@ -799,6 +802,18 @@ func customizeEl2Diff(ctx context.Context, d *schema.ResourceDiff, m interface{}
 					return fmt.Errorf("switching %s from specify_az to multi_az requires compute_node_count to be %d (current %d multiplied by %d AZs)", whLabel, expected, oldCount, len(azs))
 				}
 			}
+			// multi_az AZ-count change (2↔3): backend keeps per-AZ count fixed
+			// and recomputes total as perAZ × len(newAZs); the caller's
+			// compute_node_count must match or backend math diverges from state.
+			if oldPolicy == MULTI_AZ && len(oldSpecifiedAZs) > 0 && len(azs) != len(oldSpecifiedAZs) {
+				if oldCount%len(oldSpecifiedAZs) != 0 {
+					return fmt.Errorf("%s current compute_node_count %d is not divisible by current specified_azs count %d; cannot derive target per-AZ count", whLabel, oldCount, len(oldSpecifiedAZs))
+				}
+				expected := oldCount / len(oldSpecifiedAZs) * len(azs)
+				if cnc != expected {
+					return fmt.Errorf("changing %s multi_az specified_azs from %d to %d AZs requires compute_node_count to be %d (current %d × %d / %d)", whLabel, len(oldSpecifiedAZs), len(azs), expected, oldCount, len(azs), len(oldSpecifiedAZs))
+				}
+			}
 		} else {
 			if policy != SPECIFY_AZ && len(vMap["specify_az"].(string)) > 0 {
 				return errors.New("specify_az parameter only takes effect when the distribution_policy value is \"specify_az\"")
@@ -808,8 +823,12 @@ func customizeEl2Diff(ctx context.Context, d *schema.ResourceDiff, m interface{}
 			}
 		}
 
-		// Same-policy scaling keeps cngroup partitions evenly sized.
-		if oldCngroupCount > 0 && oldPolicy == policy && cnc != oldCount && cnc%oldCngroupCount != 0 {
+		// Same-policy scaling keeps cngroup partitions evenly sized — but
+		// multi_az AZ-count changes (2↔3) add or drop cngroups entirely, so
+		// the source cngroup_count is no longer the relevant divisor for
+		// those transitions.
+		azCountChanged := oldPolicy == MULTI_AZ && policy == MULTI_AZ && len(oldSpecifiedAZs) > 0 && len(oldSpecifiedAZs) != len(azs)
+		if oldCngroupCount > 0 && oldPolicy == policy && !azCountChanged && cnc != oldCount && cnc%oldCngroupCount != 0 {
 			return fmt.Errorf("%s compute_node_count %d must be a multiple of current cngroup_count %d", whLabel, cnc, oldCngroupCount)
 		}
 
@@ -2397,7 +2416,7 @@ func updateWarehouse(ctx context.Context, req *UpdateWarehouseReq, multiAz bool)
 	newSpecifiedAZs := toStringSlice(newParamMap["specified_azs"])
 	computeNodeDistributionChanged := oldParamMap["distribution_policy"].(string) != newParamMap["distribution_policy"].(string) ||
 		(newParamMap["distribution_policy"].(string) == string(cluster.DistributionPolicySpecifyAZ) && oldParamMap["specify_az"].(string) != newParamMap["specify_az"].(string)) ||
-		(newParamMap["distribution_policy"].(string) == string(cluster.DistributionPolicyMultiAZ) && !reflect.DeepEqual(oldSpecifiedAZs, newSpecifiedAZs))
+		(newParamMap["distribution_policy"].(string) == string(cluster.DistributionPolicyMultiAZ) && !equalAsSet(oldSpecifiedAZs, newSpecifiedAZs))
 	if computeNodeDistributionChanged && multiAz {
 		distributionPolicy := newParamMap["distribution_policy"].(string)
 		specifyAz := newParamMap["specify_az"].(string)
@@ -3664,6 +3683,41 @@ func toStringSlice(v interface{}) []string {
 		}
 	}
 	return out
+}
+
+// equalAsSet reports whether a and b contain the same elements regardless of order.
+// specified_azs is order-insensitive semantically (cngroups are derived per-AZ),
+// but the schema is TypeList; treat list-reorder as no diff.
+func equalAsSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := make(map[string]struct{}, len(a))
+	for _, s := range a {
+		seen[s] = struct{}{}
+	}
+	for _, s := range b {
+		if _, ok := seen[s]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// suppressSpecifiedAZsDiff suppresses plan diffs caused purely by reordering
+// specified_azs. Terraform invokes this for both the count key (".#") and each
+// element index; in either case we resolve the parent list and compare as sets.
+func suppressSpecifiedAZsDiff(k, _, _ string, d *schema.ResourceData) bool {
+	lastDot := strings.LastIndex(k, ".")
+	if lastDot < 0 {
+		return false
+	}
+	parent := k[:lastDot]
+	if !strings.HasSuffix(parent, ".specified_azs") {
+		return false
+	}
+	oldList, newList := d.GetChange(parent)
+	return equalAsSet(toStringSlice(oldList), toStringSlice(newList))
 }
 
 func configArrowFlight(ctx context.Context, clusterAPI cluster.IClusterAPI, req *cluster.SetClusterArrowFlightReq) diag.Diagnostics {

--- a/docs/resources/elastic_cluster_v2.md
+++ b/docs/resources/elastic_cluster_v2.md
@@ -189,7 +189,7 @@ The `celerdatabyoc_elastic_cluster_v2` resource contains the following required 
     - `auto_scaling_policy`: (Optional) This policy will automatically scale the number of compute nodes, based on CPU utilization of the warehouse. For more information, see [Enable Auto Scaling for your warehouse](https://docs.celerdata.com/BYOC/docs/cluster_management/scale_cluster#compute-autoscaling). You can generate the `policy_json` value for this argument using the [`celerdatabyoc_auto_scaling_policy`](../resources/warehouse_auto_scaling_policy.md) resource.
     - `distribution_policy`: (Optional, available only for AWS) The compute node distribution policy for the warehouse if you want to enable Multi-AZ deployment for the cluster. Valid values:
         - `specify_az`: Nodes are deployed in the primary availability zone.
-        - `multi_az`: Nodes are distributed evenly across the two availability zones specified in `specified_azs`. `compute_node_count` is required and must be a positive multiple of `len(specified_azs)`.
+        - `multi_az`: Nodes are distributed evenly across the availability zones specified in `specified_azs` (2 or 3 AZs). `compute_node_count` is required and must be a positive multiple of `len(specified_azs)`.
         - `crossing_az`: **Deprecated.** Cannot be used when creating a new warehouse or changing the `distribution_policy` of an existing warehouse; `terraform plan` will reject it. Warehouses already provisioned with `crossing_az` continue to work unchanged; migrate them to `multi_az` or `specify_az` when convenient.
 
       For more information, see [Multi-AZ Deployment](https://docs.celerdata.com/BYOC/docs/get_started/create_cluster/aws_cluster/multi-az/).
@@ -198,7 +198,7 @@ The `celerdatabyoc_elastic_cluster_v2` resource contains the following required 
 
     - `specify_az`: (Optional, available only for AWS) The primary availability zone for node deployment. This argument is available only when `distribution_policy` is set to `specify_az`.
 
-    - `specified_azs`: (Optional, available only for AWS) The list of availability zones across which compute nodes are evenly distributed. This argument is available only when `distribution_policy` is set to `multi_az`, and must contain exactly 2 AZs. `compute_node_count` must be a positive multiple of the length of this list.
+    - `specified_azs`: (Optional, available only for AWS) The list of availability zones across which compute nodes are evenly distributed. This argument is available only when `distribution_policy` is set to `multi_az`, and must contain 2 or 3 distinct AZs. `compute_node_count` must be a positive multiple of the length of this list. Changing the AZ count for an existing `multi_az` warehouse (e.g. 2→3 or 3→2) is supported in-place; the per-AZ node count is preserved and `compute_node_count` must equal `current_count × len(new_specified_azs) / len(current_specified_azs)`.
 
 - `custom_ami`: (Optional, available only for AWS) The Amazon Machine Image (AMI) used to deploy the cluster. You can use custom AMI for deployment. You can only specify this parameter when creating the cluster. If this argument is not specified, the default AMI is used.
   - `ami`: The ID of the custom AMI.
@@ -247,7 +247,7 @@ The `celerdatabyoc_elastic_cluster_v2` resource contains the following required 
 
     - `distribution_policy`: (Available only for AWS) The Compute Node distribution policy for the warehouse if you want to enable Multi-AZ deployment for the cluster. Valid values:
         - `specify_az`: Nodes are deployed in the primary availability zone.
-        - `multi_az`: Nodes are distributed evenly across the two availability zones specified in `specified_azs`. `compute_node_count` is required and must be a positive multiple of `len(specified_azs)`. When changing the warehouse size under this policy, `compute_node_count` is forwarded to the backend in a single distribution change, so no subsequent scale operation is issued.
+        - `multi_az`: Nodes are distributed evenly across the availability zones specified in `specified_azs` (2 or 3 AZs). `compute_node_count` is required and must be a positive multiple of `len(specified_azs)`. When changing the warehouse size under this policy, `compute_node_count` is forwarded to the backend in a single distribution change, so no subsequent scale operation is issued.
         - `crossing_az`: **Deprecated.** Cannot be used when creating a new warehouse or changing the `distribution_policy` of an existing warehouse; `terraform plan` will reject it. Warehouses already provisioned with `crossing_az` continue to work unchanged; migrate them to `multi_az` or `specify_az` when convenient.
 
       For more information, see [Multi-AZ Deployment](https://docs.celerdata.com/BYOC/docs/get_started/create_cluster/aws_cluster/multi-az/).
@@ -256,7 +256,7 @@ The `celerdatabyoc_elastic_cluster_v2` resource contains the following required 
 
     - `specify_az`:  (Available only for AWS) The primary availability zone for node deployment. This argument is available only when `distribution_policy` is set to `specify_az`.
 
-    - `specified_azs`: (Available only for AWS) The list of availability zones across which compute nodes are evenly distributed. This argument is available only when `distribution_policy` is set to `multi_az`, and must contain exactly 2 AZs. `compute_node_count` must be a positive multiple of the length of this list.
+    - `specified_azs`: (Available only for AWS) The list of availability zones across which compute nodes are evenly distributed. This argument is available only when `distribution_policy` is set to `multi_az`, and must contain 2 or 3 distinct AZs. `compute_node_count` must be a positive multiple of the length of this list. Changing the AZ count for an existing `multi_az` warehouse (e.g. 2→3 or 3→2) is supported in-place; the per-AZ node count is preserved and `compute_node_count` must equal `current_count × len(new_specified_azs) / len(current_specified_azs)`.
 - `global_session_variables`: Global session variables of the cluster. You can find all configurable variables by `select VARIABLE_NAME from information_schema.global_variables;`.
 - `ldap_ssl_certs`: (Available only for AWS) The path in the AWS S3 bucket that stores the LDAP SSL certificates. Multiple paths must be separated by commas (,). CelerData supports using LDAP over SSL by uploading the LDAP SSL certificates from S3. To allow CelerData to successfully fetch the certificates, you must grant the `ListObject` and `GetObject` permissions to CelerData. To delete the certificates uploaded, you only need to remove this argument.
 


### PR DESCRIPTION
- specified_azs accepts 2 or 3 AZs (was exactly 2); MaxItems=3.
- Allow in-place AZ-count changes (2↔3) for existing multi_az warehouses.
- Treat specified_azs as a set: reorders are not plan diffs.
- Update elastic_cluster_v2.md.