### PR TITLE
[BugFix] Narrow ScaleWarehouseNum skip to multi_az AZ-count change only

### DIFF
--- a/celerdatabyoc/resource_elastic_cluster_v2.go
+++ b/celerdatabyoc/resource_elastic_cluster_v2.go
@@ -3346,18 +3346,21 @@ func handleScaleWarehouses(ctx context.Context, d *schema.ResourceData, clusterA
 			if !ok {
 				continue
 			}
-			// Skip when ChangeWarehouseDistribution already handled the count
-			// change: cross-policy, or same-policy multi_az with different
-			// specified_azs (e.g. 2↔3 AZ-count change). The redundant
-			// ScaleWarehouseNum would otherwise hit "vm_num cannot be the same
-			// as the current number" / "invalid warehouse node count".
+			// Skip when ChangeWarehouseDistribution already moved the count:
+			// cross-policy honors the caller's NodeCount, and same-policy
+			// multi_az with a different AZ count (2↔3) auto-recomputes total
+			// as perAZ × len(newAZs). Same-AZ-count membership swap leaves
+			// count unchanged on backend, so ScaleWarehouseNum must still run
+			// to apply any caller-requested count change.
 			oldPolicy := oldWh["distribution_policy"].(string)
 			newPolicy := newWh["distribution_policy"].(string)
 			if oldPolicy != newPolicy {
 				continue
 			}
+			oldAZs := toStringSlice(oldWh["specified_azs"])
+			newAZs := toStringSlice(newWh["specified_azs"])
 			if newPolicy == string(cluster.DistributionPolicyMultiAZ) &&
-				!equalAsSet(toStringSlice(oldWh["specified_azs"]), toStringSlice(newWh["specified_azs"])) {
+				len(oldAZs) != len(newAZs) {
 				continue
 			}
 			whExternalInfoStr := whExternalInfoMap[whName].(string)
@@ -3378,16 +3381,20 @@ func handleScaleWarehouses(ctx context.Context, d *schema.ResourceData, clusterA
 		defaultOldWh := defaultOld.([]interface{})[0].(map[string]interface{})
 		defaultNewWh := defaultNew.([]interface{})[0].(map[string]interface{})
 
-		// Same skip rule as extra warehouses: ChangeWarehouseDistribution
-		// already adjusted the count for cross-policy and same-policy
-		// multi_az AZ-set changes.
+		// Same skip rule as extra warehouses: skip only when
+		// ChangeWarehouseDistribution moved the count (cross-policy or
+		// multi_az AZ-count change). Same-AZ-count membership swap falls
+		// through to ScaleWarehouseNum so caller-requested count changes
+		// are not silently dropped.
 		oldPolicy := defaultOldWh["distribution_policy"].(string)
 		newPolicy := defaultNewWh["distribution_policy"].(string)
 		if oldPolicy != newPolicy {
 			return nil
 		}
+		oldAZs := toStringSlice(defaultOldWh["specified_azs"])
+		newAZs := toStringSlice(defaultNewWh["specified_azs"])
 		if newPolicy == string(cluster.DistributionPolicyMultiAZ) &&
-			!equalAsSet(toStringSlice(defaultOldWh["specified_azs"]), toStringSlice(defaultNewWh["specified_azs"])) {
+			len(oldAZs) != len(newAZs) {
 			return nil
 		}
 


### PR DESCRIPTION
The previous skip rule (introduced in 91ccb3e) treated any multi_az specified_azs difference as "ChangeWarehouseDistribution already moved the count" and skipped the fallback ScaleWarehouseNum. That holds for 2↔3 AZ-count changes, where the backend auto-recomputes total as perAZ × len(newAZs). It does NOT hold for same-AZ-count membership swaps (e.g. [a,c] → [b,c]): backend's same-policy multi_az formula yields perAZ × oldAZcount = oldCount, leaving count unchanged.

Combining a same-AZ-count swap with a compute_node_count change in a single apply therefore lost the count update silently — backend kept the old count, provider's tail Scale was skipped, TF state diverged.

Tighten the skip condition to len(oldAZs) != len(newAZs) so same-AZ- count swaps fall through to ScaleWarehouseNum and apply the caller's requested count. 2↔3 AZ-count changes still skip (backend handled it), cross-policy still skips (backend honored NodeCount).