### PR TITLE
[Fix] Align crossing_az validation with backend (allow create and specify_az transition)

### DIFF
--- a/celerdatabyoc/resource_elastic_cluster_v2.go
+++ b/celerdatabyoc/resource_elastic_cluster_v2.go
@@ -811,13 +811,8 @@ func customizeEl2Diff(ctx context.Context, d *schema.ResourceDiff, m interface{}
 			oldSpecifiedAZs = toStringSlice(oldWhMap["specified_azs"])
 		}
 
-		if policy == CROSSING_AZ {
-			if oldWhMap == nil {
-				return fmt.Errorf("distribution_policy %q is no longer supported for new warehouses; use %q or %q instead (%s)", CROSSING_AZ, SPECIFY_AZ, MULTI_AZ, whLabel)
-			}
-			if oldPolicy != CROSSING_AZ {
-				return fmt.Errorf("changing distribution_policy to %q is no longer supported; existing %q warehouses remain unchanged but cannot be recreated with this policy (%s)", CROSSING_AZ, CROSSING_AZ, whLabel)
-			}
+		if policy == CROSSING_AZ && oldPolicy == MULTI_AZ {
+			return fmt.Errorf("switching distribution_policy from %q to %q is not supported (%s)", MULTI_AZ, CROSSING_AZ, whLabel)
 		}
 
 		if policy == MULTI_AZ {


### PR DESCRIPTION
## Summary

- Narrows the Terraform `customizeEl2Diff` veto on `crossing_az` to mirror the backend rule at `sr-cloud-platform/central/service/web/service/order_service.go:586-589` — only `multi_az → crossing_az` is rejected.
- New warehouses with `distribution_policy = "crossing_az"` and `specify_az → crossing_az` transitions (needed for older clusters) are now allowed at plan time.
- Replaces the wide `if policy == CROSSING_AZ { ... }` block (which previously vetoed both new-warehouse crossing_az and any change-to-crossing_az) with a single conditional in `celerdatabyoc/resource_elastic_cluster_v2.go`.

| Scenario | Behavior |
|---|---|
| New warehouse with `crossing_az` | Allowed |
| `specify_az → crossing_az` | Allowed |
| `crossing_az → crossing_az` (no-op) | Allowed |
| `multi_az → crossing_az` | Vetoed at plan time |

## Test Plan

- [ ] `terraform apply` a fresh `celerdatabyoc_elastic_cluster_v2` whose default warehouse has `distribution_policy = "crossing_az"` — expect success.
- [ ] Add a new `warehouse` block with `distribution_policy = "crossing_az"` to an existing cluster — expect success.
- [ ] Change an existing `specify_az` warehouse to `"crossing_az"` — expect plan diff shown and `apply` succeeds.
- [ ] Change an existing `multi_az` warehouse to `"crossing_az"` — expect plan-time error `switching distribution_policy from "multi_az" to "crossing_az" is not supported ...`.
- [ ] `terraform apply` no-op on an existing `crossing_az` warehouse — expect no diff, no error.