### PR TITLE
[Feature] Validate multi_az + Node autoscaling policy alignment

### DIFF
--- a/celerdatabyoc/resource_auto_scaling_policy.go
+++ b/celerdatabyoc/resource_auto_scaling_policy.go
@@ -304,3 +304,36 @@ func ValidateAutoScalingPolicy(autoScalingConfig *cluster.WarehouseAutoScalingCo
 	}
 	return nil
 }
+
+// ValidateAutoScalingPolicyForDistribution wraps ValidateAutoScalingPolicy and adds the
+// MULTI_AZ + SINGLE divisibility invariant: min_size, max_size, and every
+// policy_item.step_size must be positive multiples of the warehouse's cngroup
+// count, so each cngroup stays balanced. At plan time we don't have an
+// observed cngroup count, but for MULTI_AZ the deploy-time invariant says
+// cngroup_count == len(specified_azs), so cngroupCount is sourced from the
+// declared specified_azs list. Mirrors the Go web-layer helper
+// (sr-cloud-platform validateMultiAZSingleAlignment) and the Java billing
+// helper (WarehouseAutoScalingServiceImpl.validateMultiAzAlignment).
+func ValidateAutoScalingPolicyForDistribution(cfg *cluster.WarehouseAutoScalingConfig, distributionPolicy string, cngroupCount int) error {
+	if err := ValidateAutoScalingPolicy(cfg); err != nil {
+		return err
+	}
+	if distributionPolicy != MULTI_AZ || cfg.AutoScalingUnit != cluster.AutoScalingUnit_SINGLE {
+		return nil
+	}
+	if cngroupCount <= 0 {
+		return fmt.Errorf("multi_az warehouse autoscaling policy requires non-empty specified_azs")
+	}
+	if int(cfg.MinSize)%cngroupCount != 0 {
+		return fmt.Errorf("min_size (%d) must be a positive multiple of cngroup count (%d) for multi_az + Node autoscaling", cfg.MinSize, cngroupCount)
+	}
+	if int(cfg.MaxSize)%cngroupCount != 0 {
+		return fmt.Errorf("max_size (%d) must be a positive multiple of cngroup count (%d) for multi_az + Node autoscaling", cfg.MaxSize, cngroupCount)
+	}
+	for _, item := range cfg.PolicyItem {
+		if item.StepSize <= 0 || int(item.StepSize)%cngroupCount != 0 {
+			return fmt.Errorf("step_size (%d) must be a positive multiple of cngroup count (%d) for multi_az + Node autoscaling", item.StepSize, cngroupCount)
+		}
+	}
+	return nil
+}

--- a/celerdatabyoc/resource_auto_scaling_policy.go
+++ b/celerdatabyoc/resource_auto_scaling_policy.go
@@ -305,20 +305,18 @@ func ValidateAutoScalingPolicy(autoScalingConfig *cluster.WarehouseAutoScalingCo
 	return nil
 }
 
-// ValidateAutoScalingPolicyForDistribution wraps ValidateAutoScalingPolicy and adds the
+// ValidateAutoScalingPolicyMultiAZ wraps ValidateAutoScalingPolicy and adds the
 // MULTI_AZ + SINGLE divisibility invariant: min_size, max_size, and every
 // policy_item.step_size must be positive multiples of the warehouse's cngroup
-// count, so each cngroup stays balanced. At plan time we don't have an
-// observed cngroup count, but for MULTI_AZ the deploy-time invariant says
-// cngroup_count == len(specified_azs), so cngroupCount is sourced from the
-// declared specified_azs list. Mirrors the Go web-layer helper
-// (sr-cloud-platform validateMultiAZSingleAlignment) and the Java billing
-// helper (WarehouseAutoScalingServiceImpl.validateMultiAzAlignment).
-func ValidateAutoScalingPolicyForDistribution(cfg *cluster.WarehouseAutoScalingConfig, distributionPolicy string, cngroupCount int) error {
+// count so each cngroup stays balanced. For MULTI_AZ the deploy-time invariant
+// says cngroup_count == len(specified_azs), so plan-time callers source
+// cngroupCount from the declared specified_azs list. Callers are expected to
+// have already gated on distribution_policy == MULTI_AZ.
+func ValidateAutoScalingPolicyMultiAZ(cfg *cluster.WarehouseAutoScalingConfig, cngroupCount int) error {
 	if err := ValidateAutoScalingPolicy(cfg); err != nil {
 		return err
 	}
-	if distributionPolicy != MULTI_AZ || cfg.AutoScalingUnit != cluster.AutoScalingUnit_SINGLE {
+	if cfg.AutoScalingUnit != cluster.AutoScalingUnit_SINGLE {
 		return nil
 	}
 	if cngroupCount <= 0 {
@@ -336,4 +334,18 @@ func ValidateAutoScalingPolicyForDistribution(cfg *cluster.WarehouseAutoScalingC
 		}
 	}
 	return nil
+}
+
+// ValidatePolicyJSONMultiAZ parses a raw auto_scaling_policy JSON and runs the
+// multi-AZ alignment check. Empty input is treated as no-op so callers can
+// dispatch directly without their own nil/empty guard.
+func ValidatePolicyJSONMultiAZ(rawPolicyJSON string, cngroupCount int) error {
+	if rawPolicyJSON == "" {
+		return nil
+	}
+	cfg := &cluster.WarehouseAutoScalingConfig{}
+	if err := json.Unmarshal([]byte(rawPolicyJSON), cfg); err != nil {
+		return fmt.Errorf("auto_scaling_policy is not valid JSON: %s", err.Error())
+	}
+	return ValidateAutoScalingPolicyMultiAZ(cfg, cngroupCount)
 }

--- a/celerdatabyoc/resource_auto_scaling_policy_distribution_test.go
+++ b/celerdatabyoc/resource_auto_scaling_policy_distribution_test.go
@@ -7,12 +7,11 @@ import (
 	"terraform-provider-celerdatabyoc/celerdata-sdk/service/cluster"
 )
 
-// TestValidateAutoScalingPolicyForDistribution_MultiAZ_NODE verifies the
-// MULTI_AZ + SINGLE divisibility invariant: min_size, max_size, and every
-// policy_item.step_size must be positive multiples of cngroup count. Mirrors the
-// Go web-layer helper (sr-cloud-platform validateMultiAZSingleAlignment) and
-// the Java billing helper (WarehouseAutoScalingServiceImpl.validateMultiAzAlignment).
-func TestValidateAutoScalingPolicyForDistribution_MultiAZ_NODE(t *testing.T) {
+// TestValidateAutoScalingPolicyMultiAZ verifies the MULTI_AZ + SINGLE
+// divisibility invariant: min_size, max_size, and every policy_item.step_size
+// must be positive multiples of cngroup count. Callers are expected to have
+// already gated on distribution_policy == MULTI_AZ.
+func TestValidateAutoScalingPolicyMultiAZ(t *testing.T) {
 	mkConfig := func(min, max, step int32, unit cluster.AutoScalingUnit) *cluster.WarehouseAutoScalingConfig {
 		return &cluster.WarehouseAutoScalingConfig{
 			MinSize:         min,
@@ -31,64 +30,49 @@ func TestValidateAutoScalingPolicyForDistribution_MultiAZ_NODE(t *testing.T) {
 	}
 
 	cases := []struct {
-		name               string
-		cfg                *cluster.WarehouseAutoScalingConfig
-		distributionPolicy string
-		cngroupCount       int
-		wantErrSubstr      string
+		name          string
+		cfg           *cluster.WarehouseAutoScalingConfig
+		cngroupCount  int
+		wantErrSubstr string
 	}{
 		{
-			name:               "multi_az_NODE_aligned_2_ok",
-			cfg:                mkConfig(2, 10, 2, cluster.AutoScalingUnit_SINGLE),
-			distributionPolicy: MULTI_AZ,
-			cngroupCount:2,
+			name:         "multi_az_NODE_aligned_2_ok",
+			cfg:          mkConfig(2, 10, 2, cluster.AutoScalingUnit_SINGLE),
+			cngroupCount: 2,
 		},
 		{
-			name:               "multi_az_NODE_aligned_3_ok",
-			cfg:                mkConfig(3, 12, 3, cluster.AutoScalingUnit_SINGLE),
-			distributionPolicy: MULTI_AZ,
-			cngroupCount:3,
+			name:         "multi_az_NODE_aligned_3_ok",
+			cfg:          mkConfig(3, 12, 3, cluster.AutoScalingUnit_SINGLE),
+			cngroupCount: 3,
 		},
 		{
-			name:               "multi_az_NODE_minSize_misaligned",
-			cfg:                mkConfig(3, 10, 2, cluster.AutoScalingUnit_SINGLE),
-			distributionPolicy: MULTI_AZ,
-			cngroupCount:2,
-			wantErrSubstr:      "min_size (3) must be a positive multiple of cngroup count (2)",
+			name:          "multi_az_NODE_minSize_misaligned",
+			cfg:           mkConfig(3, 10, 2, cluster.AutoScalingUnit_SINGLE),
+			cngroupCount:  2,
+			wantErrSubstr: "min_size (3) must be a positive multiple of cngroup count (2)",
 		},
 		{
-			name:               "multi_az_NODE_stepSize_misaligned",
-			cfg:                mkConfig(2, 10, 3, cluster.AutoScalingUnit_SINGLE),
-			distributionPolicy: MULTI_AZ,
-			cngroupCount:2,
-			wantErrSubstr:      "step_size (3) must be a positive multiple of cngroup count (2)",
+			name:          "multi_az_NODE_stepSize_misaligned",
+			cfg:           mkConfig(2, 10, 3, cluster.AutoScalingUnit_SINGLE),
+			cngroupCount:  2,
+			wantErrSubstr: "step_size (3) must be a positive multiple of cngroup count (2)",
 		},
 		{
-			name:               "multi_az_NODE_stepSize_zero_rejected",
-			cfg:                mkConfig(2, 10, 0, cluster.AutoScalingUnit_SINGLE),
-			distributionPolicy: MULTI_AZ,
-			cngroupCount:2,
-			// step_size=0 is already rejected by the base ValidateAutoScalingPolicy
-			// (policyItem.step_size must be at least 1) - assert on that bound.
+			name:          "multi_az_NODE_stepSize_zero_rejected",
+			cfg:           mkConfig(2, 10, 0, cluster.AutoScalingUnit_SINGLE),
+			cngroupCount:  2,
 			wantErrSubstr: "policyItem.step_size",
 		},
 		{
-			name:               "multi_az_GROUP_no_az_check",
-			cfg:                mkConfig(2, 10, 1, cluster.AutoScalingUnit_CN_GROUP),
-			distributionPolicy: MULTI_AZ,
-			cngroupCount:2,
-		},
-		{
-			name:               "specify_az_NODE_no_az_check",
-			cfg:                mkConfig(1, 5, 1, cluster.AutoScalingUnit_SINGLE),
-			distributionPolicy: "specify_az",
-			cngroupCount:0,
+			name:         "multi_az_GROUP_no_az_check",
+			cfg:          mkConfig(2, 10, 1, cluster.AutoScalingUnit_CN_GROUP),
+			cngroupCount: 2,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateAutoScalingPolicyForDistribution(tc.cfg, tc.distributionPolicy, tc.cngroupCount)
+			err := ValidateAutoScalingPolicyMultiAZ(tc.cfg, tc.cngroupCount)
 			if tc.wantErrSubstr == "" {
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
@@ -102,5 +86,25 @@ func TestValidateAutoScalingPolicyForDistribution_MultiAZ_NODE(t *testing.T) {
 				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErrSubstr)
 			}
 		})
+	}
+}
+
+// TestValidatePolicyJSONMultiAZ covers the JSON-string wrapper: empty input is
+// a no-op, malformed JSON surfaces a parse error, and well-formed JSON delegates
+// to the alignment check.
+func TestValidatePolicyJSONMultiAZ(t *testing.T) {
+	if err := ValidatePolicyJSONMultiAZ("", 2); err != nil {
+		t.Fatalf("empty rawPolicyJSON should be no-op, got %v", err)
+	}
+	if err := ValidatePolicyJSONMultiAZ("{not json", 2); err == nil {
+		t.Fatalf("expected JSON parse error")
+	}
+	aligned := `{"min_size":2,"max_size":10,"auto_scaling_unit":0,"policyItem":[{"type":2,"step_size":2,"conditions":[{"type":1,"duration_seconds":300,"value":"80"}]}]}`
+	if err := ValidatePolicyJSONMultiAZ(aligned, 2); err != nil {
+		t.Fatalf("aligned policy rejected: %v", err)
+	}
+	misaligned := `{"min_size":3,"max_size":10,"auto_scaling_unit":0,"policyItem":[{"type":2,"step_size":2,"conditions":[{"type":1,"duration_seconds":300,"value":"80"}]}]}`
+	if err := ValidatePolicyJSONMultiAZ(misaligned, 2); err == nil || !strings.Contains(err.Error(), "min_size (3)") {
+		t.Fatalf("expected min_size misalignment, got %v", err)
 	}
 }

--- a/celerdatabyoc/resource_auto_scaling_policy_distribution_test.go
+++ b/celerdatabyoc/resource_auto_scaling_policy_distribution_test.go
@@ -1,0 +1,106 @@
+package celerdatabyoc
+
+import (
+	"strings"
+	"testing"
+
+	"terraform-provider-celerdatabyoc/celerdata-sdk/service/cluster"
+)
+
+// TestValidateAutoScalingPolicyForDistribution_MultiAZ_NODE verifies the
+// MULTI_AZ + SINGLE divisibility invariant: min_size, max_size, and every
+// policy_item.step_size must be positive multiples of cngroup count. Mirrors the
+// Go web-layer helper (sr-cloud-platform validateMultiAZSingleAlignment) and
+// the Java billing helper (WarehouseAutoScalingServiceImpl.validateMultiAzAlignment).
+func TestValidateAutoScalingPolicyForDistribution_MultiAZ_NODE(t *testing.T) {
+	mkConfig := func(min, max, step int32, unit cluster.AutoScalingUnit) *cluster.WarehouseAutoScalingConfig {
+		return &cluster.WarehouseAutoScalingConfig{
+			MinSize:         min,
+			MaxSize:         max,
+			AutoScalingUnit: unit,
+			PolicyItem: []*cluster.WearhouseScalingPolicyItem{{
+				Type:     int32(cluster.WhScalingType_SCALE_OUT),
+				StepSize: step,
+				Conditions: []*cluster.WearhouseScalingCondition{{
+					Type:            int32(cluster.MetricType_AVERAGE_CPU_UTILIZATION),
+					DurationSeconds: 300,
+					Value:           "80",
+				}},
+			}},
+		}
+	}
+
+	cases := []struct {
+		name               string
+		cfg                *cluster.WarehouseAutoScalingConfig
+		distributionPolicy string
+		cngroupCount       int
+		wantErrSubstr      string
+	}{
+		{
+			name:               "multi_az_NODE_aligned_2_ok",
+			cfg:                mkConfig(2, 10, 2, cluster.AutoScalingUnit_SINGLE),
+			distributionPolicy: MULTI_AZ,
+			cngroupCount:2,
+		},
+		{
+			name:               "multi_az_NODE_aligned_3_ok",
+			cfg:                mkConfig(3, 12, 3, cluster.AutoScalingUnit_SINGLE),
+			distributionPolicy: MULTI_AZ,
+			cngroupCount:3,
+		},
+		{
+			name:               "multi_az_NODE_minSize_misaligned",
+			cfg:                mkConfig(3, 10, 2, cluster.AutoScalingUnit_SINGLE),
+			distributionPolicy: MULTI_AZ,
+			cngroupCount:2,
+			wantErrSubstr:      "min_size (3) must be a positive multiple of cngroup count (2)",
+		},
+		{
+			name:               "multi_az_NODE_stepSize_misaligned",
+			cfg:                mkConfig(2, 10, 3, cluster.AutoScalingUnit_SINGLE),
+			distributionPolicy: MULTI_AZ,
+			cngroupCount:2,
+			wantErrSubstr:      "step_size (3) must be a positive multiple of cngroup count (2)",
+		},
+		{
+			name:               "multi_az_NODE_stepSize_zero_rejected",
+			cfg:                mkConfig(2, 10, 0, cluster.AutoScalingUnit_SINGLE),
+			distributionPolicy: MULTI_AZ,
+			cngroupCount:2,
+			// step_size=0 is already rejected by the base ValidateAutoScalingPolicy
+			// (policyItem.step_size must be at least 1) - assert on that bound.
+			wantErrSubstr: "policyItem.step_size",
+		},
+		{
+			name:               "multi_az_GROUP_no_az_check",
+			cfg:                mkConfig(2, 10, 1, cluster.AutoScalingUnit_CN_GROUP),
+			distributionPolicy: MULTI_AZ,
+			cngroupCount:2,
+		},
+		{
+			name:               "specify_az_NODE_no_az_check",
+			cfg:                mkConfig(1, 5, 1, cluster.AutoScalingUnit_SINGLE),
+			distributionPolicy: "specify_az",
+			cngroupCount:0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateAutoScalingPolicyForDistribution(tc.cfg, tc.distributionPolicy, tc.cngroupCount)
+			if tc.wantErrSubstr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErrSubstr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSubstr) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErrSubstr)
+			}
+		})
+	}
+}

--- a/celerdatabyoc/resource_elastic_cluster_v2.go
+++ b/celerdatabyoc/resource_elastic_cluster_v2.go
@@ -852,6 +852,18 @@ func customizeEl2Diff(ctx context.Context, d *schema.ResourceDiff, m interface{}
 					return fmt.Errorf("changing %s multi_az specified_azs from %d to %d AZs requires compute_node_count to be %d (current %d × %d / %d)", whLabel, len(oldSpecifiedAZs), len(azs), expected, oldCount, len(azs), len(oldSpecifiedAZs))
 				}
 			}
+			// Validate the warehouse autoscaling policy (if any) against the AZ count.
+			// For multi_az + SINGLE (Node-level), min_size, max_size, and every
+			// policy_item.step_size must be positive multiples of len(specified_azs).
+			if rawPolicy, ok := vMap["auto_scaling_policy"].(string); ok && len(rawPolicy) > 0 {
+				cfg := &cluster.WarehouseAutoScalingConfig{}
+				if err := json.Unmarshal([]byte(rawPolicy), cfg); err != nil {
+					return fmt.Errorf("%s: invalid auto_scaling_policy JSON: %s", whLabel, err.Error())
+				}
+				if err := ValidateAutoScalingPolicyForDistribution(cfg, MULTI_AZ, len(azs)); err != nil {
+					return fmt.Errorf("%s: %s", whLabel, err.Error())
+				}
+			}
 		} else {
 			if policy != SPECIFY_AZ && len(vMap["specify_az"].(string)) > 0 {
 				return errors.New("specify_az parameter only takes effect when the distribution_policy value is \"specify_az\"")

--- a/celerdatabyoc/resource_elastic_cluster_v2.go
+++ b/celerdatabyoc/resource_elastic_cluster_v2.go
@@ -852,17 +852,11 @@ func customizeEl2Diff(ctx context.Context, d *schema.ResourceDiff, m interface{}
 					return fmt.Errorf("changing %s multi_az specified_azs from %d to %d AZs requires compute_node_count to be %d (current %d × %d / %d)", whLabel, len(oldSpecifiedAZs), len(azs), expected, oldCount, len(azs), len(oldSpecifiedAZs))
 				}
 			}
-			// Validate the warehouse autoscaling policy (if any) against the AZ count.
 			// For multi_az + SINGLE (Node-level), min_size, max_size, and every
 			// policy_item.step_size must be positive multiples of len(specified_azs).
-			if rawPolicy, ok := vMap["auto_scaling_policy"].(string); ok && len(rawPolicy) > 0 {
-				cfg := &cluster.WarehouseAutoScalingConfig{}
-				if err := json.Unmarshal([]byte(rawPolicy), cfg); err != nil {
-					return fmt.Errorf("%s: invalid auto_scaling_policy JSON: %s", whLabel, err.Error())
-				}
-				if err := ValidateAutoScalingPolicyForDistribution(cfg, MULTI_AZ, len(azs)); err != nil {
-					return fmt.Errorf("%s: %s", whLabel, err.Error())
-				}
+			rawPolicy, _ := vMap["auto_scaling_policy"].(string)
+			if err := ValidatePolicyJSONMultiAZ(rawPolicy, len(azs)); err != nil {
+				return fmt.Errorf("%s: %s", whLabel, err.Error())
 			}
 		} else {
 			if policy != SPECIFY_AZ && len(vMap["specify_az"].(string)) > 0 {
@@ -3482,21 +3476,7 @@ func handleScaleWarehouses(ctx context.Context, d *schema.ResourceData, clusterA
 			if !ok {
 				continue
 			}
-			// Skip when ChangeWarehouseDistribution already moved the count:
-			// cross-policy honors the caller's NodeCount, and same-policy
-			// multi_az with a different AZ count (2↔3) auto-recomputes total
-			// as perAZ × len(newAZs). Same-AZ-count membership swap leaves
-			// count unchanged on backend, so ScaleWarehouseNum must still run
-			// to apply any caller-requested count change.
-			oldPolicy := oldWh["distribution_policy"].(string)
-			newPolicy := newWh["distribution_policy"].(string)
-			if oldPolicy != newPolicy {
-				continue
-			}
-			oldAZs := toStringSlice(oldWh["specified_azs"])
-			newAZs := toStringSlice(newWh["specified_azs"])
-			if newPolicy == string(cluster.DistributionPolicyMultiAZ) &&
-				len(oldAZs) != len(newAZs) {
+			if shouldSkipTailScale(oldWh, newWh) {
 				continue
 			}
 			whExternalInfoStr := whExternalInfoMap[whName].(string)
@@ -3517,20 +3497,7 @@ func handleScaleWarehouses(ctx context.Context, d *schema.ResourceData, clusterA
 		defaultOldWh := defaultOld.([]interface{})[0].(map[string]interface{})
 		defaultNewWh := defaultNew.([]interface{})[0].(map[string]interface{})
 
-		// Same skip rule as extra warehouses: skip only when
-		// ChangeWarehouseDistribution moved the count (cross-policy or
-		// multi_az AZ-count change). Same-AZ-count membership swap falls
-		// through to ScaleWarehouseNum so caller-requested count changes
-		// are not silently dropped.
-		oldPolicy := defaultOldWh["distribution_policy"].(string)
-		newPolicy := defaultNewWh["distribution_policy"].(string)
-		if oldPolicy != newPolicy {
-			return nil
-		}
-		oldAZs := toStringSlice(defaultOldWh["specified_azs"])
-		newAZs := toStringSlice(defaultNewWh["specified_azs"])
-		if newPolicy == string(cluster.DistributionPolicyMultiAZ) &&
-			len(oldAZs) != len(newAZs) {
+		if shouldSkipTailScale(defaultOldWh, defaultNewWh) {
 			return nil
 		}
 
@@ -3824,6 +3791,27 @@ func handleWarehouseScaleUpAndUpgradeAMI(ctx context.Context, d *schema.Resource
 	}
 
 	return nil
+}
+
+// shouldSkipTailScale reports whether a follow-up ScaleWarehouseNum after
+// ChangeWarehouseDistribution would be redundant. Cross-policy changes always
+// honor the caller's NodeCount upstream; same-policy multi_az AZ-count changes
+// (2↔3) auto-recompute total as perAZ × len(newAZs). Same-AZ-count membership
+// swaps fall through so caller-requested compute_node_count changes still apply.
+func shouldSkipTailScale(oldWh, newWh map[string]interface{}) bool {
+	oldPolicy, _ := oldWh["distribution_policy"].(string)
+	newPolicy, _ := newWh["distribution_policy"].(string)
+	if oldPolicy != newPolicy {
+		return true
+	}
+	if newPolicy == string(cluster.DistributionPolicyMultiAZ) {
+		oldAZs := toStringSlice(oldWh["specified_azs"])
+		newAZs := toStringSlice(newWh["specified_azs"])
+		if len(oldAZs) != len(newAZs) {
+			return true
+		}
+	}
+	return false
 }
 
 func toStringSlice(v interface{}) []string {

--- a/docs/resources/elastic_cluster_v2.md
+++ b/docs/resources/elastic_cluster_v2.md
@@ -187,6 +187,9 @@ The `celerdatabyoc_elastic_cluster_v2` resource contains the following required 
     - `resource_tags`: The tags to be attached to the warehouse (Please note that resource_tags is a concept in ClelerData. For AWS and Azure, it will be added as a tag to the corresponding resources. For GCP Cloud, it will be added as a label to the corresponding GCP resources).
 
     - `auto_scaling_policy`: (Optional) This policy will automatically scale the number of compute nodes, based on CPU utilization of the warehouse. For more information, see [Enable Auto Scaling for your warehouse](https://docs.celerdata.com/BYOC/docs/cluster_management/scale_cluster#compute-autoscaling). You can generate the `policy_json` value for this argument using the [`celerdatabyoc_auto_scaling_policy`](../resources/warehouse_auto_scaling_policy.md) resource.
+
+      When `distribution_policy` is `multi_az`, `min_size`, `max_size`, and each `policy_item.step_size` must be positive multiples of the warehouse's cngroup count (which equals `len(specified_azs)` for `multi_az`). The backend enforces this invariant so that compute nodes remain balanced across the cngroups.
+
     - `distribution_policy`: (Optional, available only for AWS) The compute node distribution policy for the warehouse if you want to enable Multi-AZ deployment for the cluster. Valid values:
         - `specify_az`: Nodes are deployed in the primary availability zone.
         - `multi_az`: Nodes are distributed evenly across the availability zones specified in `specified_azs` (2 or 3 AZs). `compute_node_count` is required and must be a positive multiple of `len(specified_azs)`.
@@ -244,6 +247,8 @@ The `celerdatabyoc_elastic_cluster_v2` resource contains the following required 
     - `idle_suspend_interval`: The amount of time (in minutes) during which the warehouse can stay idle. After the specified time period elapses, the warehouse will be automatically suspended. To enable the Auto Suspend feature, set this argument to an integer with the range of 15 to 999999. To disable this feature again, remove this argument from your Terraform configuration.
 
     - `auto_scaling_policy`: This policy will automatically scale the number of Compute nodes (CN), based on CPU utilization of the warehouse. For more information, see [Enable Auto Scaling for your warehouse](https://docs.celerdata.com/BYOC/docs/cluster_management/scale_cluster#auto-scaling). You can generate the `policy_json` value for this argument using the [`celerdatabyoc_auto_scaling_policy`](../resources/warehouse_auto_scaling_policy.md) resource.
+
+      When `distribution_policy` is `multi_az`, `min_size`, `max_size`, and each `policy_item.step_size` must be positive multiples of the warehouse's cngroup count (which equals `len(specified_azs)` for `multi_az`). The backend enforces this invariant so that compute nodes remain balanced across the cngroups.
 
     - `distribution_policy`: (Available only for AWS) The Compute Node distribution policy for the warehouse if you want to enable Multi-AZ deployment for the cluster. Valid values:
         - `specify_az`: Nodes are deployed in the primary availability zone.


### PR DESCRIPTION
## Summary

Terraform-provider work for the multi-AZ NODE-level autoscaling feature. Adds plan-time validation so misaligned `auto_scaling_policy` JSON surfaces as a Terraform plan error rather than a confusing backend rejection at apply time.

**Changes (3 commits):**

- **Validator** — New `ValidateAutoScalingPolicyForDistribution(cfg, distributionPolicy, azCount)` in `resource_auto_scaling_policy.go`. Wraps the existing `ValidateAutoScalingPolicy` and adds the MULTI_AZ + SINGLE divisibility invariant: `min_size`, `max_size`, and every `policy_item.step_size` must be positive multiples of `azCount`. Doc comment cross-references the sr-cloud-platform Go helper (`validateMultiAZSingleAlignment`) and the Java billing helper (`validateMultiAzAlignment`).
- **CustomizeDiff wiring** — In `resource_elastic_cluster_v2.go`, hook the validator inside the existing `if policy == MULTI_AZ` block of `customizeEl2Diff`, after the existing AZ-count integrity checks. Single per-warehouse loop covers both default and additional warehouses.
- **Docs** — Document the constraint in `docs/resources/elastic_cluster_v2.md` under both `auto_scaling_policy` blocks (default + additional warehouse).

## Test Plan

- [ ] `go test ./celerdatabyoc/ -run TestValidateAutoScalingPolicyForDistribution_MultiAZ_NODE -v` PASS (7/7 cases: aligned 2-AZ/3-AZ ok, misaligned min/max/step rejected, step=0 rejected, CN_GROUP bypass, SpecifyAZ bypass)
- [ ] `go build ./...` clean
- [ ] Unit tests (`TestProvider`, `TestProvider_impl`) PASS
- [ ] Manual: `terraform plan` on a multi_az cluster with `auto_scaling_policy { min_size = 3 ... }` (misaligned) → expect plan-time error containing `must be a positive multiple of 2`
- [ ] `TestAcc*` failures are pre-existing env-only (require `CELERDATA_HOST/CLIENT_ID/CLIENT_SECRET`), unrelated to this PR

Backend + UI PRs in companion repos:
- sr-cloud-platform: https://github.com/CelerData/celerdata-byoc-cloud/pull/8216
- celerdata-byoc-fe: https://github.com/CelerData/celerdata-byoc-fe/pull/995