### PR TITLE
[Docs] Document Multi-AZ deployment support on GCP

### DIFF
--- a/docs/guides/gcp_deployment_guide.md
+++ b/docs/guides/gcp_deployment_guide.md
@@ -434,6 +434,98 @@ When the system returns an "Apply complete!" message, the Terraform configuratio
 
 ~> After you change the provider versions in the Terraform configuration, you must run `terraform init -upgrade` to initialize the providers and then run `terraform apply` again to apply the Terraform configuration.
 
+## Multi-AZ Deployment
+
+CelerData BYOC supports Multi-AZ deployment on GCP. A Multi-AZ cluster distributes its coordinator (FE) nodes and warehouse compute (BE) nodes across 2 or 3 zones in the same region for higher availability.
+
+### Region support
+
+GCP regions that expose 3 zones (`a`, `b`, `c`) include `us-central1`, `us-west1`, `us-east1`, and `europe-west1`. Other regions support 2-AZ deployment only. Zone names follow GCP convention: `{region}-{a|b|c}`, e.g. `us-central1-a`.
+
+### Cluster-level requirements
+
+- `coordinator_node_count` must be at least `3` (i.e. `3` or `5`). FE nodes are placed by the cluster service using a min-fe-nodes policy that keeps the per-zone FE count balanced.
+- The `celerdatabyoc_gcp_network` resource must declare the zones the cluster can span via its `zones` argument. GCP uses a single regional subnet, so the AZ set is expressed via `zones` rather than per-AZ subnets. The provider enforces `MinItems = 3` and `MaxItems = 3` on this list — you must supply **exactly 3 zones**, and the warehouse-level `specified_azs` (which may contain 2 or 3 zones) must be a subset of this list. `zones` is `ForceNew`: changing it after creation recreates the network resource.
+
+  ```hcl
+  resource "celerdatabyoc_gcp_network" "net" {
+    name                     = "tf-net-multi-az"
+    region                   = "us-central1"
+    subnet                   = "tf-subnet"
+    network_tag              = "tf-network-tag"
+    zones                    = ["us-central1-a", "us-central1-b", "us-central1-c"]
+    deployment_credential_id = celerdatabyoc_gcp_deployment_credential.deploy.id
+  }
+  ```
+
+### Warehouse-level configuration
+
+Set `distribution_policy = "multi_az"` on `default_warehouse` and on every `warehouse {}` block you want to spread across zones. `specified_azs` must contain 2 or 3 zones and `compute_node_count` must be a positive multiple of `len(specified_azs)`. Example:
+
+```hcl
+resource "celerdatabyoc_elastic_cluster_v2" "c" {
+  cluster_name           = "demo-multi-az"
+  csp                    = "gcp"
+  region                 = "us-central1"
+  coordinator_node_size  = "n2-standard-4"
+  coordinator_node_count = 3
+
+  deployment_credential_id = celerdatabyoc_gcp_deployment_credential.deploy.id
+  data_credential_id       = celerdatabyoc_gcp_data_credential.data_credential.id
+  network_id               = celerdatabyoc_gcp_network.net.id
+
+  coordinator_node_volume_config {
+    vol_size = 100
+  }
+
+  default_warehouse {
+    distribution_policy = "multi_az"
+    specified_azs       = ["us-central1-a", "us-central1-b"]
+    compute_node_size   = "n2-standard-4"
+    compute_node_count  = 2
+    compute_node_volume_config {
+      vol_number = 2
+      vol_size   = 150
+    }
+    resource_tags = {
+      warehouse_name = "default_warehouse"
+    }
+  }
+
+  warehouse {
+    name                = "wh_analytics"
+    distribution_policy = "multi_az"
+    specified_azs       = ["us-central1-a", "us-central1-b"]
+    compute_node_size   = "n2-standard-4"
+    compute_node_count  = 2
+    compute_node_volume_config {
+      vol_number = 2
+      vol_size   = 150
+    }
+    resource_tags = {
+      warehouse_name = "wh_analytics"
+    }
+  }
+
+  default_admin_password = "..."
+}
+```
+
+### GCP-specific constraints
+
+- **Disk configuration.** GCP `pd-balanced` disks do not accept Provisioned IOPS. `coordinator_node_volume_config` and `compute_node_volume_config` blocks must therefore set only `vol_size` (and `vol_number` for compute nodes). Do not specify `iops` or `throughput`; doing so causes the underlying GCP API to return `Error 400: Provisioned IOPS cannot be specified with disk type pd-balanced`.
+- **Resource labels.** Anything you place in `resource_tags` is forwarded to GCP as a resource label. GCP label keys and values must contain only lowercase letters, digits, hyphens (`-`), and underscores (`_`). Use, for example, `warehouse_name = "default_warehouse"` rather than `WarehouseName = "default_warehouse"`.
+
+### Scaling Multi-AZ warehouses
+
+The same rules apply as on AWS:
+
+- `specify_az → multi_az`: new `compute_node_count = old_count × len(specified_azs)` (preserves per-AZ node count).
+- `multi_az 2-AZ ↔ 3-AZ`: new `compute_node_count = old_count × new_az_count / old_az_count`.
+- `multi_az → specify_az`: new `compute_node_count` must be a multiple of the current `cngroup_size`.
+- Same-policy resize within `multi_az` only requires `compute_node_count` to remain a multiple of `len(specified_azs)`; AZ membership is unchanged.
+- Reordering `specified_azs` is a no-op; the provider's diff suppression treats `[a, b, c]` and `[c, a, b]` as equivalent.
+
 ## Delete configurations
 
 You can delete your Terraform configuration if you no longer need it.

--- a/docs/resources/elastic_cluster_v2.md
+++ b/docs/resources/elastic_cluster_v2.md
@@ -187,7 +187,7 @@ The `celerdatabyoc_elastic_cluster_v2` resource contains the following required 
     - `resource_tags`: The tags to be attached to the warehouse (Please note that resource_tags is a concept in ClelerData. For AWS and Azure, it will be added as a tag to the corresponding resources. For GCP Cloud, it will be added as a label to the corresponding GCP resources).
 
     - `auto_scaling_policy`: (Optional) This policy will automatically scale the number of compute nodes, based on CPU utilization of the warehouse. For more information, see [Enable Auto Scaling for your warehouse](https://docs.celerdata.com/BYOC/docs/cluster_management/scale_cluster#compute-autoscaling). You can generate the `policy_json` value for this argument using the [`celerdatabyoc_auto_scaling_policy`](../resources/warehouse_auto_scaling_policy.md) resource.
-    - `distribution_policy`: (Optional, available only for AWS) The compute node distribution policy for the warehouse if you want to enable Multi-AZ deployment for the cluster. Valid values:
+    - `distribution_policy`: (Optional, supported on AWS and GCP) The compute node distribution policy for the warehouse if you want to enable Multi-AZ deployment for the cluster. Valid values:
         - `specify_az`: Nodes are deployed in the primary availability zone.
         - `multi_az`: Nodes are distributed evenly across the availability zones specified in `specified_azs` (2 or 3 AZs). `compute_node_count` is required and must be a positive multiple of `len(specified_azs)`.
         - `crossing_az`: **Deprecated.** Cannot be used when creating a new warehouse or changing the `distribution_policy` of an existing warehouse; `terraform plan` will reject it. Warehouses already provisioned with `crossing_az` continue to work unchanged; migrate them to `multi_az` or `specify_az` when convenient.
@@ -196,9 +196,9 @@ The `celerdatabyoc_elastic_cluster_v2` resource contains the following required 
 
       ~> To enable Multi-AZ Deployment, you must deploy at least 3 coordinator nodes, that is, `coordinator_node_count` must be greater or equal to `3`.
 
-    - `specify_az`: (Optional, available only for AWS) The primary availability zone for node deployment. This argument is available only when `distribution_policy` is set to `specify_az`.
+    - `specify_az`: (Optional, supported on AWS and GCP) The primary availability zone for node deployment. This argument is available only when `distribution_policy` is set to `specify_az`. AZ naming follows the cloud convention: `us-west-2a` on AWS, `us-central1-a` on GCP.
 
-    - `specified_azs`: (Optional, available only for AWS) The list of availability zones across which compute nodes are evenly distributed. This argument is available only when `distribution_policy` is set to `multi_az`, and must contain 2 or 3 distinct AZs. `compute_node_count` must be a positive multiple of the length of this list. Changing the AZ count for an existing `multi_az` warehouse (e.g. 2→3 or 3→2) is supported in-place; the per-AZ node count is preserved and `compute_node_count` must equal `current_count × len(new_specified_azs) / len(current_specified_azs)`.
+    - `specified_azs`: (Optional, supported on AWS and GCP) The list of availability zones across which compute nodes are evenly distributed. This argument is available only when `distribution_policy` is set to `multi_az`, and must contain 2 or 3 distinct AZs. `compute_node_count` must be a positive multiple of the length of this list. Changing the AZ count for an existing `multi_az` warehouse (e.g. 2→3 or 3→2) is supported in-place; the per-AZ node count is preserved and `compute_node_count` must equal `current_count × len(new_specified_azs) / len(current_specified_azs)`.
 
 - `custom_ami`: (Optional, available only for AWS) The Amazon Machine Image (AMI) used to deploy the cluster. You can use custom AMI for deployment. You can only specify this parameter when creating the cluster. If this argument is not specified, the default AMI is used.
   - `ami`: The ID of the custom AMI.
@@ -216,7 +216,7 @@ The `celerdatabyoc_elastic_cluster_v2` resource contains the following required 
 
 **Optional:**
 
-- `coordinator_node_count`: The number of coordinator nodes in the cluster. Valid values: `1`, `3`, and `5`. Default value: `1`. If you want to enable Multi-AZ Deployment (Available only for AWS), you must deploy at least 3 Coordinator Nodes, that is, `coordinator_node_count` must be greater or equal to `3`.
+- `coordinator_node_count`: The number of coordinator nodes in the cluster. Valid values: `1`, `3`, and `5`. Default value: `1`. If you want to enable Multi-AZ Deployment (supported on AWS and GCP), you must deploy at least 3 Coordinator Nodes, that is, `coordinator_node_count` must be greater or equal to `3`.
 
 - `coordinator_node_volume_config`: The coordinator nodes volume configuration.
     - `vol_size`: The size per disk for each coordinator node. Unit: GB. Default value: `150`. You can only increase the value of this parameter.
@@ -245,7 +245,7 @@ The `celerdatabyoc_elastic_cluster_v2` resource contains the following required 
 
     - `auto_scaling_policy`: This policy will automatically scale the number of Compute nodes (CN), based on CPU utilization of the warehouse. For more information, see [Enable Auto Scaling for your warehouse](https://docs.celerdata.com/BYOC/docs/cluster_management/scale_cluster#auto-scaling). You can generate the `policy_json` value for this argument using the [`celerdatabyoc_auto_scaling_policy`](../resources/warehouse_auto_scaling_policy.md) resource.
 
-    - `distribution_policy`: (Available only for AWS) The Compute Node distribution policy for the warehouse if you want to enable Multi-AZ deployment for the cluster. Valid values:
+    - `distribution_policy`: (Supported on AWS and GCP) The Compute Node distribution policy for the warehouse if you want to enable Multi-AZ deployment for the cluster. Valid values:
         - `specify_az`: Nodes are deployed in the primary availability zone.
         - `multi_az`: Nodes are distributed evenly across the availability zones specified in `specified_azs` (2 or 3 AZs). `compute_node_count` is required and must be a positive multiple of `len(specified_azs)`. When changing the warehouse size under this policy, `compute_node_count` is forwarded to the backend in a single distribution change, so no subsequent scale operation is issued.
         - `crossing_az`: **Deprecated.** Cannot be used when creating a new warehouse or changing the `distribution_policy` of an existing warehouse; `terraform plan` will reject it. Warehouses already provisioned with `crossing_az` continue to work unchanged; migrate them to `multi_az` or `specify_az` when convenient.
@@ -254,9 +254,9 @@ The `celerdatabyoc_elastic_cluster_v2` resource contains the following required 
 
       ~> To enable Multi-AZ Deployment, you must deploy at least 3 Coordinator Nodes, that is, `coordinator_node_count` must be greater or equal to `3`.
 
-    - `specify_az`:  (Available only for AWS) The primary availability zone for node deployment. This argument is available only when `distribution_policy` is set to `specify_az`.
+    - `specify_az`:  (Supported on AWS and GCP) The primary availability zone for node deployment. This argument is available only when `distribution_policy` is set to `specify_az`. AZ naming follows the cloud convention: `us-west-2a` on AWS, `us-central1-a` on GCP.
 
-    - `specified_azs`: (Available only for AWS) The list of availability zones across which compute nodes are evenly distributed. This argument is available only when `distribution_policy` is set to `multi_az`, and must contain 2 or 3 distinct AZs. `compute_node_count` must be a positive multiple of the length of this list. Changing the AZ count for an existing `multi_az` warehouse (e.g. 2→3 or 3→2) is supported in-place; the per-AZ node count is preserved and `compute_node_count` must equal `current_count × len(new_specified_azs) / len(current_specified_azs)`.
+    - `specified_azs`: (Supported on AWS and GCP) The list of availability zones across which compute nodes are evenly distributed. This argument is available only when `distribution_policy` is set to `multi_az`, and must contain 2 or 3 distinct AZs. `compute_node_count` must be a positive multiple of the length of this list. Changing the AZ count for an existing `multi_az` warehouse (e.g. 2→3 or 3→2) is supported in-place; the per-AZ node count is preserved and `compute_node_count` must equal `current_count × len(new_specified_azs) / len(current_specified_azs)`.
 - `global_session_variables`: Global session variables of the cluster. You can find all configurable variables by `select VARIABLE_NAME from information_schema.global_variables;`.
 - `ldap_ssl_certs`: (Available only for AWS) The path in the AWS S3 bucket that stores the LDAP SSL certificates. Multiple paths must be separated by commas (,). CelerData supports using LDAP over SSL by uploading the LDAP SSL certificates from S3. To allow CelerData to successfully fetch the certificates, you must grant the `ListObject` and `GetObject` permissions to CelerData. To delete the certificates uploaded, you only need to remove this argument.
 

--- a/docs/resources/gcp_network.md
+++ b/docs/resources/gcp_network.md
@@ -15,11 +15,14 @@ The implementation of this resource can be part of the whole cluster deployment 
 
 ```terraform
 resource "celerdatabyoc_gcp_network" "network_credential" {
-  name = "<network_credential_name>"
-  region = "<region_name>"
-  subnet = "<subnet>"
-  network_tag = "<network_tag>"
+  name                     = "<network_credential_name>"
+  region                   = "<region_name>"
+  subnet                   = "<subnet>"
+  network_tag              = "<network_tag>"
   deployment_credential_id = "<deployment_credential_id>"
+
+  # Required for Multi-AZ deployments. Must list exactly 3 zones in the region.
+  zones                    = ["<region>-a", "<region>-b", "<region>-c"]
 }
 ```
 
@@ -35,7 +38,7 @@ This resource contains the following required arguments and optional arguments:
 
 - `region`: (Forces new resource) The Name of the GCP region.
 
-- `subnet`: (Forces new resource) The Name of GCP subnet.
+- `subnet`: (Forces new resource) The Name of GCP subnet. Use this argument in place of the deprecated `subnet_name` argument.
 
 - `network_tag`: (Forces new resource) The target tag of the firewall rules that you use to enable connectivity between cluster nodes within your own VPC and between CelerData's VPC and your own VPC over TLS.
 
@@ -43,12 +46,16 @@ This resource contains the following required arguments and optional arguments:
 
 **Optional:**
 
+- `zones`: (Forces new resource) The list of GCP zones (e.g. `["us-central1-a", "us-central1-b", "us-central1-c"]`) in which cluster nodes may be placed. **Exactly 3 zones must be supplied** (the resource enforces both `MinItems = 3` and `MaxItems = 3`). This argument is required to deploy a Multi-AZ cluster — the zones a warehouse's `specified_azs` references must be a subset of this list. For single-AZ deployments the argument is optional; if omitted, the backend chooses a default zone.
+
 - `psc_connection_id`: (Forces new resource) The ID of the [Private Service Connect](https://cloud.google.com/vpc/docs/private-service-connect) connection that you create to allow direct, secure connectivity between CelerData's VPC and your own VPC.
   
   For information about how to create a PSC Connection, see [Create a Private Service Connect Endpoint](https://docs.celerdata.com/BYOC/docs/sql-reference/gcp/create_psc_endpoint/).
   NOTE:
     - If PSC connection ID is not set, then the Private Service Connect connection will not be built, CelerData's VPC communicates with your own VPC over the Internet.
     - If you have enabled Shared VPC, you should enter the ID of the PSC Connection from the service project (that is, the project where the cluster is deployed)..
+
+- `subnet_name`: (Forces new resource, **Deprecated**) Old name for the `subnet` argument. Kept only for backward compatibility; use `subnet` for all new configurations.
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Summary

- Documentation has been claiming Multi-AZ is AWS-only, but the provider already supports it on GCP (verified end-to-end on stage GCP in `us-central1` with `distribution_policy=multi_az`, `cngroup_count=2`).
- Update `elastic_cluster_v2`, `gcp_network`, and the GCP deployment guide so the docs reflect the actual schema and behavior.

## What changed

- `docs/resources/elastic_cluster_v2.md`
  - Relabel `distribution_policy`, `specify_az`, `specified_azs`, and the Multi-AZ coordinator note from "(available only for AWS)" → "(supported on AWS and GCP)".
  - Add a note on AZ naming (`us-west-2a` on AWS vs `us-central1-a` on GCP).
- `docs/resources/gcp_network.md`
  - Document the previously-undocumented `zones` argument (`MinItems=3`, `MaxItems=3`, `ForceNew`) — required for Multi-AZ, and the warehouse-level `specified_azs` must be a subset of it.
  - Document the deprecated `subnet_name` argument and point users at `subnet`.
  - Add a Multi-AZ example.
- `docs/guides/gcp_deployment_guide.md`
  - New `## Multi-AZ Deployment` section: supported regions, `coordinator_node_count >= 3`, the `gcp_network.zones` constraint, a full HCL example, GCP-specific gotchas (pd-balanced rejects `iops`/`throughput`; labels must be lowercase), and the same-as-AWS scaling rules.

## Test plan

- [x] Verified each new field/section against the current Go schema (`resource_elastic_cluster_v2.go`, `resource_gcp_network.go`).
- [x] Verified end-to-end on stage GCP: built a Multi-AZ cluster with `distribution_policy=multi_az`, `specified_azs=[us-central1-a, us-central1-b]`, `compute_node_count=2` — applied cleanly and tfstate reports the expected `cngroup_count=2`, `cngroup_size=1` for both `default_warehouse` and an extra `warehouse`.
- [ ] Maintainer to render the Terraform Registry preview and confirm headings/anchors look right.