### PR TITLE
[Feature] Add scope to ranger_config resource

### DIFF
--- a/celerdata-sdk/service/ranger-config/entity.go
+++ b/celerdata-sdk/service/ranger-config/entity.go
@@ -1,5 +1,15 @@
 package rangerconfig
 
+// Ranger scope values. Mirrors the backend RangerScope enum.
+const (
+	// RangerScopeAllCatalogs makes Ranger govern all catalogs (internal + external);
+	// access_control=ranger is written to fe.conf. This is the default.
+	RangerScopeAllCatalogs = 0
+	// RangerScopeExternalOnly makes Ranger govern external catalogs only; internal
+	// catalogs keep StarRocks native RBAC and access_control=ranger is not written.
+	RangerScopeExternalOnly = 1
+)
+
 type RangerConfig struct {
 	Name                               string `json:"name" mapstructure:"name"`
 	BizID                              string `json:"biz_id" mapstructure:"biz_id"`
@@ -12,6 +22,7 @@ type RangerConfig struct {
 	RangerStarrocksKeyStoreCredPath    string `json:"ranger_starrocks_key_store_cred_path" mapstructure:"ranger_starrocks_key_store_cred_path"`
 	RangerHiveSecurityXmlPath          string `json:"ranger_hive_security_xml_path" mapstructure:"ranger_hive_security_xml_path"`
 	RangerHiveAuditXmlPath             string `json:"ranger_hive_audit_xml_path" mapstructure:"ranger_hive_audit_xml_path"`
+	Scope                              int    `json:"scope,omitempty" mapstructure:"scope"`
 }
 
 type CreateRangerConfigReq struct {

--- a/celerdatabyoc/resource_ranger_config.go
+++ b/celerdatabyoc/resource_ranger_config.go
@@ -2,6 +2,7 @@ package celerdatabyoc
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"regexp"
 	"terraform-provider-celerdatabyoc/celerdata-sdk/client"
@@ -18,12 +19,21 @@ func resourceRangerConfig() *schema.Resource {
 		ReadContext:   resourceRangerConfigRead,
 		DeleteContext: resourceRangerConfigDelete,
 		UpdateContext: resourceRangerConfigUpdate,
+		CustomizeDiff: resourceRangerConfigCustomizeDiff,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,
 				ForceNew:     true,
 				Required:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"scope": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      rangerconfig.RangerScopeAllCatalogs,
+				ValidateFunc: validation.IntInSlice([]int{rangerconfig.RangerScopeAllCatalogs, rangerconfig.RangerScopeExternalOnly}),
+				Description: "Ranger scope: 0 = all catalogs (internal + external, writes access_control=ranger to fe.conf), " +
+					"1 = external catalogs only (internal catalogs keep StarRocks native RBAC). Defaults to 0.",
 			},
 			"ranger_starrocks_security_xml_path": {
 				Type:         schema.TypeString,
@@ -73,6 +83,29 @@ func resourceRangerConfig() *schema.Resource {
 	}
 }
 
+// resourceRangerConfigCustomizeDiff enforces the same security-xml requirement as the backend
+// validateRangerConfig, so users get a plan-time error instead of an apply-time API rejection:
+//   - scope=0 (all catalogs): ranger_starrocks_security_xml_path is required.
+//   - scope=1 (external only): at least one of ranger_starrocks_security_xml_path or
+//     ranger_hive_security_xml_path is required, otherwise no external catalog can be governed.
+func resourceRangerConfigCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
+	scope := d.Get("scope").(int)
+	starrocksXml := d.Get("ranger_starrocks_security_xml_path").(string)
+	hiveXml := d.Get("ranger_hive_security_xml_path").(string)
+
+	if scope == rangerconfig.RangerScopeExternalOnly {
+		if len(starrocksXml) == 0 && len(hiveXml) == 0 {
+			return fmt.Errorf("scope=1 (external catalogs only) requires at least one of " +
+				"ranger_starrocks_security_xml_path or ranger_hive_security_xml_path")
+		}
+		return nil
+	}
+	if len(starrocksXml) == 0 {
+		return fmt.Errorf("scope=0 (all catalogs) requires ranger_starrocks_security_xml_path")
+	}
+	return nil
+}
+
 func resourceRangerConfigCreate(ctx context.Context, d *schema.ResourceData, m interface{}) (diags diag.Diagnostics) {
 	c := m.(*client.CelerdataClient)
 	cli := rangerconfig.NewRangerConfigAPI(c)
@@ -89,6 +122,7 @@ func resourceRangerConfigCreate(ctx context.Context, d *schema.ResourceData, m i
 			RangerStarrocksKeyStoreCredPath:    d.Get("ranger_starrocks_key_store_cred_path").(string),
 			RangerHiveSecurityXmlPath:          d.Get("ranger_hive_security_xml_path").(string),
 			RangerHiveAuditXmlPath:             d.Get("ranger_hive_audit_xml_path").(string),
+			Scope:                              d.Get("scope").(int),
 		},
 	}
 
@@ -118,6 +152,7 @@ func resourceRangerConfigUpdate(ctx context.Context, d *schema.ResourceData, m i
 			RangerStarrocksKeyStoreCredPath:    d.Get("ranger_starrocks_key_store_cred_path").(string),
 			RangerHiveSecurityXmlPath:          d.Get("ranger_hive_security_xml_path").(string),
 			RangerHiveAuditXmlPath:             d.Get("ranger_hive_audit_xml_path").(string),
+			Scope:                              d.Get("scope").(int),
 		},
 	}
 

--- a/docs/resources/ranger_config.md
+++ b/docs/resources/ranger_config.md
@@ -51,21 +51,21 @@ This resource contains the following required arguments and optional arguments:
 
 - `ranger_starrocks_security_xml_path`: The remote storage path to the `ranger-starrocks-security.xml` file, which is the configuration file used in conjunction between StarRocks and Apache Ranger. Required when `scope` is `0`. When `scope` is `1`, this argument and `ranger_hive_security_xml_path` are independent and at least one of them must be set.
 
-- `ranger_starrocks_audit_xml_path`: (Forces new resource) The remote storage path to the `ranger-starrocks-audit.xml` file, which is used to enable the Audit Log service of Ranger. 
+- `ranger_starrocks_audit_xml_path`: The remote storage path to the `ranger-starrocks-audit.xml` file, which is used to enable the Audit Log service of Ranger. 
 
-- `ranger_starrocks_policymgr_ssl_xml_path`: (Forces new resource) The remote storage path to the `ranger-policymgr-ssl.xml` file, which is used to specify the actual local paths (on the server) of the corresponding files for the Trust Store or Key Store.
+- `ranger_starrocks_policymgr_ssl_xml_path`: The remote storage path to the `ranger-policymgr-ssl.xml` file, which is used to specify the actual local paths (on the server) of the corresponding files for the Trust Store or Key Store.
 
-- `ranger_starrocks_trust_store_path`: (Forces new resource) The remote storage path to the `truststore.jks` file. Specify this argument if you want to enable secure connection via Trust Store.
+- `ranger_starrocks_trust_store_path`: The remote storage path to the `truststore.jks` file. Specify this argument if you want to enable secure connection via Trust Store.
 
-- `ranger_starrocks_trust_store_cred_path`: (Forces new resource) The remote storage path to the `truststore.jceks` file. Specify this argument if you want to enable secure connection via Trust Store.
+- `ranger_starrocks_trust_store_cred_path`: The remote storage path to the `truststore.jceks` file. Specify this argument if you want to enable secure connection via Trust Store.
 
-- `ranger_starrocks_key_store_path`: (Forces new resource) The remote storage path to the `keystore.jks` file. Specify this argument if you want to enable secure connection via Key Store.
+- `ranger_starrocks_key_store_path`: The remote storage path to the `keystore.jks` file. Specify this argument if you want to enable secure connection via Key Store.
 
-- `ranger_starrocks_key_store_cred_path`: (Forces new resource) The remote storage path to the `keystore.jceks` file. Specify this argument if you want to enable secure connection via Key Store.
+- `ranger_starrocks_key_store_cred_path`: The remote storage path to the `keystore.jceks` file. Specify this argument if you want to enable secure connection via Key Store.
 
 - `ranger_hive_security_xml_path`: The remote storage path to the `ranger-hive-security.xml` file, which is used to enable Ranger's access control for Hive Catalog. When `scope` is `1`, at least one of this argument and `ranger_starrocks_security_xml_path` must be set.
 
-- `ranger_hive_audit_xml_path`: (Forces new resource) The remote storage path to the `ranger-hive-audit.xml` file, which is used to enable Ranger's Audit Log service for Hive Catalog.
+- `ranger_hive_audit_xml_path`: The remote storage path to the `ranger-hive-audit.xml` file, which is used to enable Ranger's Audit Log service for Hive Catalog.
 
 ## Attribute Reference
 

--- a/docs/resources/ranger_config.md
+++ b/docs/resources/ranger_config.md
@@ -19,6 +19,7 @@ A Ranger configuration specifies the remote storage paths to the configuration f
 ```terraform
 resource "celerdatabyoc_ranger_config" "ranger_config" {
   name                               = "<ranger_config_name>"
+  scope                              = 0
   ranger_starrocks_security_xml_path = "<path_to_ranger-starrocks-security.xml>"
 
   ranger_starrocks_audit_xml_path = "<path_to_ranger-starrocks-audit.xml>"
@@ -44,9 +45,11 @@ This resource contains the following required arguments and optional arguments:
 
 - `name`: (Forces new resource) The name of the Ranger configuration. Enter a unique name.
 
-- `ranger_starrocks_security_xml_path`: (Forces new resource) The remote storage path to the `ranger-starrocks-security.xml` file, which is the configuration file used in conjunction between StarRocks and Apache Ranger.
-
 **Optional:**
+
+- `scope`: The catalogs that Ranger governs. Valid values: `0` (all catalogs, internal + external) and `1` (external catalogs only). Defaults to `0`. With `0`, `access_control=ranger` is written to `fe.conf`, so Ranger becomes the access control for all catalogs (internal catalogs no longer use StarRocks native RBAC). With `1`, `access_control=ranger` is not written: internal catalogs keep StarRocks native RBAC and Ranger governs only external catalogs.
+
+- `ranger_starrocks_security_xml_path`: The remote storage path to the `ranger-starrocks-security.xml` file, which is the configuration file used in conjunction between StarRocks and Apache Ranger. Required when `scope` is `0`. When `scope` is `1`, this argument and `ranger_hive_security_xml_path` are independent and at least one of them must be set.
 
 - `ranger_starrocks_audit_xml_path`: (Forces new resource) The remote storage path to the `ranger-starrocks-audit.xml` file, which is used to enable the Audit Log service of Ranger. 
 
@@ -60,7 +63,7 @@ This resource contains the following required arguments and optional arguments:
 
 - `ranger_starrocks_key_store_cred_path`: (Forces new resource) The remote storage path to the `keystore.jceks` file. Specify this argument if you want to enable secure connection via Key Store.
 
-- `ranger_hive_security_xml_path`: (Forces new resource) The remote storage path to the `ranger-hive-security.xml` file, which is used to enable Ranger's access control for Hive Catalog.
+- `ranger_hive_security_xml_path`: The remote storage path to the `ranger-hive-security.xml` file, which is used to enable Ranger's access control for Hive Catalog. When `scope` is `1`, at least one of this argument and `ranger_starrocks_security_xml_path` must be set.
 
 - `ranger_hive_audit_xml_path`: (Forces new resource) The remote storage path to the `ranger-hive-audit.xml` file, which is used to enable Ranger's Audit Log service for Hive Catalog.
 


### PR DESCRIPTION
## What

Adds a `scope` argument to the `celerdatabyoc_ranger_config` resource, mirroring the new backend `RangerScope` field (CLD-37975).

- `scope = 0` (default): all catalogs (internal + external). Backend writes `access_control=ranger` to `fe.conf`, so Ranger governs all catalogs.
- `scope = 1`: external catalogs only. `access_control=ranger` is **not** written; internal catalogs keep StarRocks native RBAC and Ranger governs only external catalogs (routed per-catalog via the Hive or StarRocks Ranger service).

Defaults to `0`, so existing configs are unaffected.

## Validation

`CustomizeDiff` enforces the same security-xml rule as the backend `validateRangerConfig`, giving a plan-time error instead of an apply-time API rejection:

- `scope=0` requires `ranger_starrocks_security_xml_path`.
- `scope=1` requires at least one of `ranger_starrocks_security_xml_path` or `ranger_hive_security_xml_path` (otherwise no external catalog can be governed by Ranger).

## Changes

- `celerdata-sdk/service/ranger-config/entity.go`: add `Scope` field + `RangerScopeAllCatalogs`/`RangerScopeExternalOnly` constants.
- `celerdatabyoc/resource_ranger_config.go`: `scope` schema (TypeInt, default 0, IntInSlice{0,1}), `CustomizeDiff`, wired into create/update.
- `docs/resources/ranger_config.md`: document `scope` and the conditional security-xml requirement.